### PR TITLE
Make SCRAM-SHA-256/512 SASL Mechanisms available.

### DIFF
--- a/faust/types/auth.py
+++ b/faust/types/auth.py
@@ -23,6 +23,8 @@ class AuthProtocol(Enum):
 class SASLMechanism(Enum):
     PLAIN = "PLAIN"
     GSSAPI = "GSSAPI"
+    SCRAM_SHA_256 = "SCRAM-SHA-256"
+    SCRAM_SHA_512 = "SCRAM-SHA-512"
 
 
 AUTH_PROTOCOLS_SSL = {AuthProtocol.SSL, AuthProtocol.SASL_SSL}

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -45,6 +45,15 @@ class test_SASLCredentials:
                     "protocol": AuthProtocol.SASL_SSL,
                 },
             ),
+            pytest.param(
+                "SCRAM-SHA-512 supported",
+                SASLCredentials(
+                    username="george",
+                    password="pw1",
+                    mechanism=SASLMechanism.SCRAM_SHA_512,
+                ),
+                {"mechanism": SASLMechanism.SCRAM_SHA_512},
+            ),
         ],
     )
     def test_constructor(self, credentials, expected_fields, reason):


### PR DESCRIPTION
Fixes robinhood/faust#601.

## Description

Please describe your pull request.

Makes SCRAM-SHA-256/SCRAM-SHA-512 SASL Mechanisms available.

Tested against a Kafka 2.5.0 cluster with success.
