### PR TITLE
fix(aiokafka): release all fetch waiters

### DIFF
--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -804,11 +804,14 @@ class AIOKafkaConsumerThread(ConsumerThread):
         if consumer._closed or fetcher._closed:
             raise ConsumerStoppedError()
         with fetcher._subscriptions.fetch_context():
-            return await fetcher.fetched_records(
-                active_partitions,
-                timeout=timeout,
-                max_records=max_records,
-            )
+            try:
+                return await fetcher.fetched_records(
+                    active_partitions,
+                    timeout=timeout,
+                    max_records=max_records,
+                )
+            finally:
+                fetcher._fetch_waiters.clear()
 
     async def create_topic(
         self,


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

This implements the patch suggested by @ask to fix the memory growth when no messages are arriving on a topic.

All waiting fetchers are released every time fetched_records is called so the list doesn't grow until the next message is received.