### PR TITLE
Return float from Cython implementation of HoppingWindow.ranges

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,12 +11,18 @@ on:
 
 jobs:
   tests:
-    name: "Python ${{ matrix.python-version }}"
+    name: "Python ${{ matrix.python-version }}/Cython: ${{ matrix.use-cython }}"
     runs-on: "ubuntu-latest"
 
     strategy:
+      # Complete all jobs even if one fails, allows us to see
+      # for example if a test fails only when Cython is enabled
+      fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8"]
+        use-cython: ["true", "false"]
+    env:
+      USE_CYTHON: ${{ matrix.use-cython }}
 
     steps:
       - uses: "actions/checkout@v2"

--- a/faust/_cython/windows.pyx
+++ b/faust/_cython/windows.pyx
@@ -64,7 +64,7 @@ cdef class HoppingWindow:
         r = []
         for start in range(int(start), int(timestamp) + 1, int(self.step)):
             end = start + self.size - 0.1
-            r.append((start, end))
+            r.append((float(start), end))
         return r
 
     cdef double _start_initial_range(self, double timestamp):

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -7,5 +7,5 @@ fi
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=61
+${PREFIX}coverage report --show-missing --skip-covered --fail-under=60
 codecov --token=$CODECOV_TOKEN

--- a/scripts/install
+++ b/scripts/install
@@ -15,5 +15,10 @@ else
     PIP="pip"
 fi
 
+if [ -n "$GITHUB_ACTIONS" ] && [ "x$USE_CYTHON" = "xtrue" ] ; then
+    $PIP install Cython
+    FAST="[fast]"
+fi
+
 "$PIP" install -r "$REQUIREMENTS"
-"$PIP" install -e .
+"$PIP" install -e .${FAST}

--- a/tests/unit/windows/test_hopping_window.py
+++ b/tests/unit/windows/test_hopping_window.py
@@ -1,7 +1,9 @@
+from pytest import approx
+
 from faust.windows import HoppingWindow
 
 
-class test_HoppingWindow:
+class Test_HoppingWindow:
     def test_has_ranges_including_the_value(self):
         size = 10
         step = 5
@@ -58,3 +60,19 @@ class test_HoppingWindow:
         for time in range(0, now_timestamp - expires):
             print(f"TIME: {time} NOW TIMESTAMP: {now_timestamp}")
             assert window.stale(time, now_timestamp) is True
+
+    def test_ranges_types(self):
+        size = 60
+        step = 60
+        window = HoppingWindow(size, step)
+
+        # There's nothing special about this timestamp,
+        # it was simply when the test was created
+        timestamp = 1603122451.544989
+        window_ranges = window.ranges(timestamp)
+
+        assert len(window_ranges) == 1
+        assert type(window_ranges[0][0]) == float
+        assert type(window_ranges[0][1]) == float
+        assert window_ranges[0][0] == approx(1603122420.0)
+        assert window_ranges[0][1] == approx(1603122479.9)


### PR DESCRIPTION
## Description

This PR addresses robinhood/faust#674, where using the Cython implementation of HoppingWindow makes the table functionality (at least together with RocksDB) worthless.

It also adds one dimension to the matrix in the github action, making the tests be run with and without Cython enabled, trying to catch any future bugs like this. 

The test included in the PR has been proven to fail on Cython without the patch to the actual code, see [this test run](https://github.com/forsberg/faust-streaming/actions/runs/365487074)

As the Cython code is not counted in coverage, I had to decrease the accepted coverage percenage to 60%, or the coverage enforcement would always fail on Cython since windows.py was not counted as covered. There may be better ways to do solve this.