### PR TITLE
Fixed ack for tombstones in cython-stream

### DIFF
--- a/faust/_cython/streams.pyx
+++ b/faust/_cython/streams.pyx
@@ -81,13 +81,14 @@ cdef class StreamIterator:
         do_ack = stream.enable_acks
 
         value = None
+        event = None
 
-        while value is None:
+        while value is None and event is None:
             await sleep(0, loop=self.loop)
             need_slow_get, channel_value = self._try_get_quick_value()
             if need_slow_get:
                 channel_value = await self.chan_slow_get()
-            value, sensor_state = self._prepare_event(channel_value)
+            event, value, sensor_state = self._prepare_event(channel_value)
 
             try:
                 for processor in self.processors:
@@ -165,10 +166,10 @@ cdef class StreamIterator:
                 stream_state = self.on_stream_event_in(
                     tp, offset, self.stream, event)
             self.stream._set_current_event(event)
-            return (event.value, stream_state)
+            return (event, event.value, stream_state)
         else:
             self.stream._set_current_event(None)
-            return channel_value, stream_state
+            return None, channel_value, stream_state
 
     cdef object _try_get_quick_value(self):
         if self.chan_is_channel:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description
Previously, Tombstones have neither been forwarded to the processor nor ack'ed.
copy of https://github.com/robinhood/faust/pull/547

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
