### PR TITLE
Fix for canceled from mode

### DIFF
--- a/faust/_cython/streams.pyx
+++ b/faust/_cython/streams.pyx
@@ -121,7 +121,7 @@ cdef class StreamIterator:
                     if self.acks_enabled_for(message.topic):
                         committed = consumer._committed_offset[tp]
                         try:
-                            if committed is None or offset > committed:
+                            if committed is None or offset >= committed:
                                 acked_index = consumer._acked_index[tp]
                                 if offset not in acked_index:
                                     self.unacked.discard(message)

--- a/faust/agents/agent.py
+++ b/faust/agents/agent.py
@@ -669,9 +669,14 @@ class Agent(AgentT, Service):
         _current_agent.set(self)
         try:
             await coro
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as exc:
             if self.should_stop:
                 raise
+            else:
+                self.log.info("Restarting on rebalance")
+                await aref.crash(exc)
+                self.supervisor.wakeup()
+
         except Exception as exc:
             if self._on_error is not None:
                 await self._on_error(self, exc)

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -1028,7 +1028,7 @@ class Consumer(Service, ConsumerT):
             # find first list of consecutive numbers
             batch = next(consecutive_numbers(acked))
             # remove them from the list to clean up.
-            acked[: len(batch) - 1] = []
+            acked[: len(batch)] = []
             self._acked_index[tp].difference_update(batch)
             # return the highest commit offset
             return batch[-1] + 1

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -526,12 +526,21 @@ class AIOKafkaConsumerThread(ConsumerThread):
                 return False
             self.log.exception("Committing raised exception: %r", exc)
             await self.crash(exc)
+            self.supervisor.wakeup()
             return False
         except IllegalStateError as exc:
             self.log.exception(
                 "Got exception: %r\nCurrent assignment: %r", exc, self.assignment()
             )
             await self.crash(exc)
+            self.supervisor.wakeup()
+            return False
+        except Exception as exc:
+            self.log.exception(
+                "Got exception: %r\nCurrent assignment: %r", exc, self.assignment()
+            )
+            await self.crash(exc)
+            self.supervisor.wakeup()
             return False
         return True
 


### PR DESCRIPTION
fixes the issue in faust [678](https://github.com/robinhood/faust/issues/678)

This also fixes the issue where the consumer stops commuting offsets for a certain topic/partition
