### PR TITLE
Fix IPv6 address case in server_list function

### DIFF
--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -159,10 +159,24 @@ Has not committed %r (last commit %s).
 """.strip()
 
 
+def __canon_host(host, default):
+    """Ensure host is correctly formatted for aiokafka. That means IPv6
+    addresses must enclosed in squared brackets.
+    """
+    if not host:
+        return default
+    if ":" in host:
+        return f"[{host}]"
+    return host
+
+
 def server_list(urls: List[URL], default_port: int) -> List[str]:
     """Convert list of urls to list of servers accepted by :pypi:`aiokafka`."""
     default_host = "127.0.0.1"
-    return [f"{u.host or default_host}:{u.port or default_port}" for u in urls]
+    # Yarl strips [] from IPv6 adresses, and aiokafka expects them.
+    return [
+        f"{__canon_host(u.host, default_host)}:{u.port or default_port}" for u in urls
+    ]
 
 
 class ConsumerRebalanceListener(aiokafka.abc.ConsumerRebalanceListener):  # type: ignore


### PR DESCRIPTION
## Description

When specifying an IPv6 address in faust.App as broker, faust passes to aiokafka an incorrectly-transformed value. 

e.g:

When I write this:
```python
faust.App('mob', broker=f'kafka://[1234:5678::9abc]')
```

yarl.URL constructor receives the strings as is, but the returned object `.host` attribute is `1234:5678::9abc`.  So, the `server_list function` in transport/drivers/aiokafka.py creates `1234:5678::9abc:9092`, which, while not syntactically incorrect, is a different IPv6 address. Also, the port information is lost in the process.

I've checked the yarl module and there does not seem to be any attribute/method to retrieve the enclosed IPv6 address. This small change intend to fix this behavior, on faust side.

L156 is assumed as a "is it an IPv6 address" check. While it could be better, I found it's good enough for me. :)
