### PR TITLE
Add web_ssl_context to allow internal web server to support https

### DIFF
--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -23,7 +23,7 @@ import sys
 import typing
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __author__ = "Robinhood Markets, Inc."
 __contact__ = "schrohm@gmail.com, vpatki@wayfair.com"
 __homepage__ = "https://github.com/faust-streaming/faust"

--- a/faust/types/settings/settings.py
+++ b/faust/types/settings/settings.py
@@ -159,6 +159,7 @@ class Settings(base.SettingsRegistry):
         web_host: str = None,
         web_in_thread: bool = None,
         web_port: int = None,
+        web_ssl_context: ssl.SSLContext = None,
         web_transport: URLArg = None,
         # Worker settings:
         worker_redirect_stdouts: bool = None,
@@ -1795,6 +1796,17 @@ class Settings(base.SettingsRegistry):
 
         This option is usually set by :option:`faust worker --web-port`,
         not by passing it as a keyword argument to :class:`app`.
+        """
+
+    @sections.WebServer.setting(
+        params.SSLContext,
+        version_introduced="0.5.0",
+        default=None,
+    )
+    def web_ssl_context(self) -> ssl.SSLContext:
+        """Web server SSL configuration.
+
+        See :setting:`credentials`.
         """
 
     @sections.WebServer.setting(

--- a/faust/web/drivers/aiohttp.py
+++ b/faust/web/drivers/aiohttp.py
@@ -292,6 +292,7 @@ class Web(base.Web):
             self._runner,
             self.app.conf.web_bind,
             self.app.conf.web_port,
+            ssl_context=self.app.conf.web_ssl_context,
         )
 
     def _new_transport_unix(self) -> BaseSite:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

Add the web_ssl_context configuration option to allow the web server to support https
