### PR TITLE
Fix for outdated sensors after rebalancing

### DIFF
--- a/faust/sensors/monitor.py
+++ b/faust/sensors/monitor.py
@@ -571,6 +571,7 @@ class Monitor(Sensor, KeywordReduce):
     def on_rebalance_start(self, app: AppT) -> Dict:
         """Cluster rebalance in progress."""
         self.rebalances = app.rebalancing_count
+        self._clear_topic_related_sensors()
         return {"time_start": self.time()}
 
     def on_rebalance_return(self, app: AppT, state: Dict) -> None:
@@ -596,6 +597,7 @@ class Monitor(Sensor, KeywordReduce):
             latency_end=latency_end,
         )
         deque_pushpopmax(self.rebalance_end_latency, latency_end, self.max_avg_history)
+        self._clear_topic_related_sensors()
 
     def on_web_request_start(
         self, app: AppT, request: web.Request, *, view: web.View = None
@@ -633,3 +635,10 @@ class Monitor(Sensor, KeywordReduce):
         substitution: str = RE_NORMALIZE_SUBSTITUTION
     ) -> str:
         return pattern.sub(substitution, name)
+
+    def _clear_topic_related_sensors(self) -> None:
+        self.tp_committed_offsets.clear()
+        self.tp_read_offsets.clear()
+        self.tp_end_offsets.clear()
+        self.topic_buffer_full.clear()
+        self.stream_inbound_time.clear()

--- a/faust/sensors/prometheus.py
+++ b/faust/sensors/prometheus.py
@@ -352,9 +352,10 @@ class PrometheusMonitor(Monitor):
         """Call when stream is done processing an event."""
         super().on_stream_event_out(tp, offset, stream, event, state)
         self._metrics.total_active_events.dec()
-        self._metrics.events_runtime_latency.observe(
-            self.secs_to_ms(self.events_runtime[-1])
-        )
+        if state is not None:
+            self._metrics.events_runtime_latency.observe(
+                self.secs_to_ms(self.events_runtime[-1])
+            )
 
     def on_message_out(self, tp: TP, offset: int, message: Message) -> None:
         """Call when message is fully acknowledged and can be committed."""

--- a/faust/sensors/prometheus.py
+++ b/faust/sensors/prometheus.py
@@ -1,6 +1,6 @@
-"""Monitor using Promethus."""
+"""Monitor using Prometheus."""
 import typing
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 from aiohttp.web import Response
 
@@ -23,12 +23,234 @@ from .monitor import Monitor, TPOffsetMapping
 
 try:
     import prometheus_client
-    from prometheus_client import REGISTRY, Counter, Gauge, Histogram, generate_latest
+    from prometheus_client import (
+        CONTENT_TYPE_LATEST,
+        REGISTRY,
+        CollectorRegistry,
+        Counter,
+        Gauge,
+        Histogram,
+        generate_latest,
+    )
 except ImportError:  # pragma: no cover
     prometheus_client = None
 
 
-__all__ = ["PrometheusMonitor"]
+__all__ = ["setup_prometheus_sensors"]
+
+
+def setup_prometheus_sensors(
+    app: AppT, pattern: str = "/metrics", registry: CollectorRegistry = REGISTRY
+) -> None:
+    if prometheus_client is None:
+        raise ImproperlyConfigured(
+            "prometheus_client requires `pip install prometheus_client`."
+        )
+
+    faust_metrics = FaustMetrics.create(registry)
+    app.monitor = PrometheusMonitor(metrics=faust_metrics)
+
+    @app.page(pattern)
+    async def metrics_handler(self: _web.View, request: _web.Request) -> _web.Response:
+        headers = {"Content-Type": CONTENT_TYPE_LATEST}
+
+        return cast(
+            _web.Response,
+            Response(body=generate_latest(REGISTRY), headers=headers, status=200),
+        )
+
+
+class FaustMetrics(NamedTuple):
+    messages_received: Counter
+    active_messages: Gauge
+    messages_received_per_topics: Counter
+    messages_received_per_topics_partition: Gauge
+    events_runtime_latency: Histogram
+
+    # On Event Stream in
+    total_events: Counter
+    total_active_events: Gauge
+    total_events_per_stream: Counter
+
+    # On table changes get/set/del keys
+    table_operations: Counter
+
+    # On message send
+    topic_messages_sent: Counter
+    total_sent_messages: Counter
+    producer_send_latency: Histogram
+    total_error_messages_sent: Counter
+    producer_error_send_latency: Histogram
+
+    # Assignment
+    assignment_operations: Counter
+    assign_latency: Histogram
+
+    # Rebalances
+    total_rebalances: Gauge
+    total_rebalances_recovering: Gauge
+    rebalance_done_consumer_latency: Histogram
+    rebalance_done_latency: Histogram
+
+    # Count Metrics by name
+    count_metrics_by_name: Gauge
+
+    # Web
+    http_status_codes: Counter
+    http_latency: Histogram
+
+    # Topic/Partition Offsets
+    topic_partition_end_offset: Gauge
+    topic_partition_offset_commited: Gauge
+    consumer_commit_latency: Histogram
+
+    @classmethod
+    def create(cls, registry: CollectorRegistry) -> "FaustMetrics":
+        messages_received = Counter(
+            "messages_received", "Total messages received", registry=registry
+        )
+        active_messages = Gauge(
+            "active_messages", "Total active messages", registry=registry
+        )
+        messages_received_per_topics = Counter(
+            "messages_received_per_topic",
+            "Messages received per topic",
+            ["topic"],
+            registry=registry,
+        )
+        messages_received_per_topics_partition = Gauge(
+            "messages_received_per_topics_partition",
+            "Messages received per topic/partition",
+            ["topic", "partition"],
+            registry=registry,
+        )
+        events_runtime_latency = Histogram(
+            "events_runtime_ms", "Events runtime in ms", registry=registry
+        )
+        total_events = Counter(
+            "total_events", "Total events received", registry=registry
+        )
+        total_active_events = Gauge(
+            "total_active_events", "Total active events", registry=registry
+        )
+        total_events_per_stream = Counter(
+            "total_events_per_stream",
+            "Events received per Stream",
+            ["stream"],
+            registry=registry,
+        )
+        table_operations = Counter(
+            "table_operations",
+            "Total table operations",
+            ["table", "operation"],
+            registry=registry,
+        )
+        topic_messages_sent = Counter(
+            "topic_messages_sent",
+            "Total messages sent per topic",
+            ["topic"],
+            registry=registry,
+        )
+        total_sent_messages = Counter(
+            "total_sent_messages", "Total messages sent", registry=registry
+        )
+        producer_send_latency = Histogram(
+            "producer_send_latency", "Producer send latency in ms", registry=registry
+        )
+        total_error_messages_sent = Counter(
+            "total_error_messages_sent", "Total error messages sent", registry=registry
+        )
+        producer_error_send_latency = Histogram(
+            "producer_error_send_latency",
+            "Producer error send latency in ms",
+            registry=registry,
+        )
+        assignment_operations = Counter(
+            "assignment_operations",
+            "Total assigment operations (completed/error)",
+            ["operation"],
+            registry=registry,
+        )
+        assign_latency = Histogram(
+            "assign_latency", "Assignment latency in ms", registry=registry
+        )
+        total_rebalances = Gauge(
+            "total_rebalances", "Total rebalances", registry=registry
+        )
+        total_rebalances_recovering = Gauge(
+            "total_rebalances_recovering",
+            "Total rebalances recovering",
+            registry=registry,
+        )
+        rebalance_done_consumer_latency = Histogram(
+            "rebalance_done_consumer_latency",
+            "Consumer replying that rebalance is done to broker in ms",
+            registry=registry,
+        )
+        rebalance_done_latency = Histogram(
+            "rebalance_done_latency",
+            "Rebalance finished latency in ms",
+            registry=registry,
+        )
+        count_metrics_by_name = Gauge(
+            "metrics_by_name", "Total metrics by name", ["metric"], registry=registry
+        )
+        http_status_codes = Counter(
+            "http_status_codes",
+            "Total http_status code",
+            ["status_code"],
+            registry=registry,
+        )
+        http_latency = Histogram(
+            "http_latency", "Http response latency in ms", registry=registry
+        )
+        topic_partition_end_offset = Gauge(
+            "topic_partition_end_offset",
+            "Offset ends per topic/partition",
+            ["topic", "partition"],
+            registry=registry,
+        )
+        topic_partition_offset_commited = Gauge(
+            "topic_partition_offset_commited",
+            "Offset commited per topic/partition",
+            ["topic", "partition"],
+            registry=registry,
+        )
+        consumer_commit_latency = Histogram(
+            "consumer_commit_latency",
+            "Consumer commit latency in ms",
+            registry=registry,
+        )
+        return cls(
+            messages_received=messages_received,
+            active_messages=active_messages,
+            messages_received_per_topics=messages_received_per_topics,
+            messages_received_per_topics_partition=(
+                messages_received_per_topics_partition
+            ),
+            events_runtime_latency=events_runtime_latency,
+            total_events=total_events,
+            total_active_events=total_active_events,
+            total_events_per_stream=total_events_per_stream,
+            table_operations=table_operations,
+            topic_messages_sent=topic_messages_sent,
+            total_sent_messages=total_sent_messages,
+            producer_send_latency=producer_send_latency,
+            total_error_messages_sent=total_error_messages_sent,
+            producer_error_send_latency=producer_error_send_latency,
+            assignment_operations=assignment_operations,
+            assign_latency=assign_latency,
+            total_rebalances=total_rebalances,
+            total_rebalances_recovering=total_rebalances_recovering,
+            rebalance_done_consumer_latency=rebalance_done_consumer_latency,
+            rebalance_done_latency=rebalance_done_latency,
+            count_metrics_by_name=count_metrics_by_name,
+            http_status_codes=http_status_codes,
+            http_latency=http_latency,
+            topic_partition_end_offset=topic_partition_end_offset,
+            topic_partition_offset_commited=topic_partition_offset_commited,
+            consumer_commit_latency=consumer_commit_latency,
+        )
 
 
 class PrometheusMonitor(Monitor):
@@ -40,10 +262,10 @@ class PrometheusMonitor(Monitor):
 
     Usage:
         import faust
-        from faust.sensors.prometheus import PrometheusMonitor
+        from faust.sensors.prometheus import setup_prometheus_sensors
 
         app = faust.App('example', broker='kafka://')
-        app.monitor = PrometheusMonitor(app, pattern='/metrics')
+        setup_prometheus_sensors(app, pattern='/metrics')
     """
 
     ERROR = "error"
@@ -52,120 +274,18 @@ class PrometheusMonitor(Monitor):
     KEYS_UPDATED = "keys_updated"
     KEYS_DELETED = "keys_deleted"
 
-    def __init__(self, app: AppT, pattern: str = "/metrics", **kwargs: Any) -> None:
-        self.app = app
-        self.pattern = pattern
-
-        if prometheus_client is None:
-            raise ImproperlyConfigured(
-                "prometheus_client requires `pip install prometheus_client`."
-            )
-
-        self._initialize_metrics()
-        self.expose_metrics()
+    def __init__(self, metrics: FaustMetrics, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-
-    def _initialize_metrics(self) -> None:
-        """
-        Initialize Prometheus metrics
-        """
-        # On message received
-        self.messages_received = Counter("messages_received", "Total messages received")
-        self.active_messages = Gauge("active_messages", "Total active messages")
-        self.messages_received_per_topics = Counter(
-            "messages_received_per_topic", "Messages received per topic", ["topic"]
-        )
-        self.messages_received_per_topics_partition = Gauge(
-            "messages_received_per_topics_partition",
-            "Messages received per topic/partition",
-            ["topic", "partition"],
-        )
-        self.events_runtime_latency = Histogram(
-            "events_runtime_ms", "Events runtime in ms"
-        )
-
-        # On Event Stream in
-        self.total_events = Counter("total_events", "Total events received")
-        self.total_active_events = Gauge("total_active_events", "Total active events")
-        self.total_events_per_stream = Counter(
-            "total_events_per_stream", "Events received per Stream", ["stream"]
-        )
-
-        # On table changes get/set/del keys
-        self.table_operations = Counter(
-            "table_operations", "Total table operations", ["table", "operation"]
-        )
-
-        # On message send
-        self.topic_messages_sent = Counter(
-            "topic_messages_sent", "Total messages sent per topic", ["topic"]
-        )
-        self.total_sent_messages = Counter("total_sent_messages", "Total messages sent")
-        self.producer_send_latency = Histogram(
-            "producer_send_latency", "Producer send latency in ms"
-        )
-        self.total_error_messages_sent = Counter(
-            "total_error_messages_sent", "Total error messages sent"
-        )
-        self.producer_error_send_latency = Histogram(
-            "producer_error_send_latency", "Producer error send latency in ms"
-        )
-
-        # Assignment
-        self.assignment_operations = Counter(
-            "assignment_operations",
-            "Total assigment operations (completed/error)",
-            ["operation"],
-        )
-        self.assign_latency = Histogram("assign_latency", "Assignment latency in ms")
-
-        # Rebalances
-        self.total_rebalances = Gauge("total_rebalances", "Total rebalances")
-        self.total_rebalances_recovering = Gauge(
-            "total_rebalances_recovering", "Total rebalances recovering"
-        )
-        self.rebalance_done_consumer_latency = Histogram(
-            "rebalance_done_consumer_latency",
-            "Consumer replying that rebalance is done to broker in ms",
-        )
-        self.rebalance_done_latency = Histogram(
-            "rebalance_done_latency", "Rebalance finished latency in ms"
-        )
-
-        # Count Metrics by name
-        self.count_metrics_by_name = Gauge(
-            "metrics_by_name", "Total metrics by name", ["metric"]
-        )
-
-        # Web
-        self.http_status_codes = Counter(
-            "http_status_codes", "Total http_status code", ["status_code"]
-        )
-        self.http_latency = Histogram("http_latency", "Http response latency in ms")
-
-        # Topic/Partition Offsets
-        self.topic_partition_end_offset = Gauge(
-            "topic_partition_end_offset",
-            "Offset ends per topic/partition",
-            ["topic", "partition"],
-        )
-        self.topic_partition_offset_commited = Gauge(
-            "topic_partition_offset_commited",
-            "Offset commited per topic/partition",
-            ["topic", "partition"],
-        )
-        self.consumer_commit_latency = Histogram(
-            "consumer_commit_latency", "Consumer commit latency in ms"
-        )
+        self._metrics = metrics
 
     def on_message_in(self, tp: TP, offset: int, message: Message) -> None:
         """Call before message is delegated to streams."""
         super().on_message_in(tp, offset, message)
 
-        self.messages_received.inc()
-        self.active_messages.inc()
-        self.messages_received_per_topics.labels(topic=tp.topic).inc()
-        self.messages_received_per_topics_partition.labels(
+        self._metrics.messages_received.inc()
+        self._metrics.active_messages.inc()
+        self._metrics.messages_received_per_topics.labels(topic=tp.topic).inc()
+        self._metrics.messages_received_per_topics_partition.labels(
             topic=tp.topic, partition=tp.partition
         ).set(offset)
 
@@ -174,9 +294,9 @@ class PrometheusMonitor(Monitor):
     ) -> typing.Optional[typing.Dict]:
         """Call when stream starts processing an event."""
         state = super().on_stream_event_in(tp, offset, stream, event)
-        self.total_events.inc()
-        self.total_active_events.inc()
-        self.total_events_per_stream.labels(
+        self._metrics.total_events.inc()
+        self._metrics.total_active_events.inc()
+        self._metrics.total_events_per_stream.labels(
             stream=f"stream.{self._stream_label(stream)}.events"
         ).inc()
 
@@ -201,18 +321,20 @@ class PrometheusMonitor(Monitor):
     ) -> None:
         """Call when stream is done processing an event."""
         super().on_stream_event_out(tp, offset, stream, event, state)
-        self.total_active_events.dec()
-        self.events_runtime_latency.observe(self.secs_to_ms(self.events_runtime[-1]))
+        self._metrics.total_active_events.dec()
+        self._metrics.events_runtime_latency.observe(
+            self.secs_to_ms(self.events_runtime[-1])
+        )
 
     def on_message_out(self, tp: TP, offset: int, message: Message) -> None:
         """Call when message is fully acknowledged and can be committed."""
         super().on_message_out(tp, offset, message)
-        self.active_messages.dec()
+        self._metrics.active_messages.dec()
 
     def on_table_get(self, table: CollectionT, key: typing.Any) -> None:
         """Call when value in table is retrieved."""
         super().on_table_get(table, key)
-        self.table_operations.labels(
+        self._metrics.table_operations.labels(
             table=f"table.{table.name}", operation=self.KEYS_RETRIEVED
         ).inc()
 
@@ -221,21 +343,23 @@ class PrometheusMonitor(Monitor):
     ) -> None:
         """Call when new value for key in table is set."""
         super().on_table_set(table, key, value)
-        self.table_operations.labels(
+        self._metrics.table_operations.labels(
             table=f"table.{table.name}", operation=self.KEYS_UPDATED
         ).inc()
 
     def on_table_del(self, table: CollectionT, key: typing.Any) -> None:
         """Call when key in a table is deleted."""
         super().on_table_del(table, key)
-        self.table_operations.labels(
+        self._metrics.table_operations.labels(
             table=f"table.{table.name}", operation=self.KEYS_DELETED
         ).inc()
 
     def on_commit_completed(self, consumer: ConsumerT, state: typing.Any) -> None:
         """Call when consumer commit offset operation completed."""
         super().on_commit_completed(consumer, state)
-        self.consumer_commit_latency.observe(self.ms_since(typing.cast(float, state)))
+        self._metrics.consumer_commit_latency.observe(
+            self.ms_since(typing.cast(float, state))
+        )
 
     def on_send_initiated(
         self,
@@ -246,7 +370,7 @@ class PrometheusMonitor(Monitor):
         valsize: int,
     ) -> typing.Any:
         """Call when message added to producer buffer."""
-        self.topic_messages_sent.labels(topic=f"topic.{topic}").inc()
+        self._metrics.topic_messages_sent.labels(topic=f"topic.{topic}").inc()
 
         return super().on_send_initiated(producer, topic, message, keysize, valsize)
 
@@ -255,16 +379,18 @@ class PrometheusMonitor(Monitor):
     ) -> None:
         """Call when producer finished sending message."""
         super().on_send_completed(producer, state, metadata)
-        self.total_sent_messages.inc()
-        self.producer_send_latency.observe(self.ms_since(typing.cast(float, state)))
+        self._metrics.total_sent_messages.inc()
+        self._metrics.producer_send_latency.observe(
+            self.ms_since(typing.cast(float, state))
+        )
 
     def on_send_error(
         self, producer: ProducerT, exc: BaseException, state: typing.Any
     ) -> None:
         """Call when producer was unable to publish message."""
         super().on_send_error(producer, exc, state)
-        self.total_error_messages_sent.inc()
-        self.producer_error_send_latency.observe(
+        self._metrics.total_error_messages_sent.inc()
+        self._metrics.producer_error_send_latency.observe(
             self.ms_since(typing.cast(float, state))
         )
 
@@ -273,56 +399,56 @@ class PrometheusMonitor(Monitor):
     ) -> None:
         """Partition assignor did not complete assignor due to error."""
         super().on_assignment_error(assignor, state, exc)
-        self.assignment_operations.labels(operation=self.ERROR).inc()
-        self.assign_latency.observe(self.ms_since(state["time_start"]))
+        self._metrics.assignment_operations.labels(operation=self.ERROR).inc()
+        self._metrics.assign_latency.observe(self.ms_since(state["time_start"]))
 
     def on_assignment_completed(
         self, assignor: PartitionAssignorT, state: typing.Dict
     ) -> None:
         """Partition assignor completed assignment."""
         super().on_assignment_completed(assignor, state)
-        self.assignment_operations.labels(operation=self.COMPLETED).inc()
-        self.assign_latency.observe(self.ms_since(state["time_start"]))
+        self._metrics.assignment_operations.labels(operation=self.COMPLETED).inc()
+        self._metrics.assign_latency.observe(self.ms_since(state["time_start"]))
 
     def on_rebalance_start(self, app: AppT) -> typing.Dict:
         """Cluster rebalance in progress."""
         state = super().on_rebalance_start(app)
-        self.total_rebalances.inc()
+        self._metrics.total_rebalances.inc()
 
         return state
 
     def on_rebalance_return(self, app: AppT, state: typing.Dict) -> None:
         """Consumer replied assignment is done to broker."""
         super().on_rebalance_return(app, state)
-        self.total_rebalances.dec()
-        self.total_rebalances_recovering.inc()
-        self.rebalance_done_consumer_latency.observe(
+        self._metrics.total_rebalances.dec()
+        self._metrics.total_rebalances_recovering.inc()
+        self._metrics.rebalance_done_consumer_latency.observe(
             self.ms_since(state["time_return"])
         )
 
     def on_rebalance_end(self, app: AppT, state: typing.Dict) -> None:
         """Cluster rebalance fully completed (including recovery)."""
         super().on_rebalance_end(app, state)
-        self.total_rebalances_recovering.dec()
-        self.rebalance_done_latency.observe(self.ms_since(state["time_end"]))
+        self._metrics.total_rebalances_recovering.dec()
+        self._metrics.rebalance_done_latency.observe(self.ms_since(state["time_end"]))
 
     def count(self, metric_name: str, count: int = 1) -> None:
         """Count metric by name."""
         super().count(metric_name, count=count)
-        self.count_metrics_by_name.labels(metric=metric_name).inc(count)
+        self._metrics.count_metrics_by_name.labels(metric=metric_name).inc(count)
 
     def on_tp_commit(self, tp_offsets: TPOffsetMapping) -> None:
         """Call when offset in topic partition is committed."""
         super().on_tp_commit(tp_offsets)
         for tp, offset in tp_offsets.items():
-            self.topic_partition_offset_commited.labels(
+            self._metrics.topic_partition_offset_commited.labels(
                 topic=tp.topic, partition=tp.partition
             ).set(offset)
 
     def track_tp_end_offset(self, tp: TP, offset: int) -> None:
         """Track new topic partition end offset for monitoring lags."""
         super().track_tp_end_offset(tp, offset)
-        self.topic_partition_end_offset.labels(
+        self._metrics.topic_partition_end_offset.labels(
             topic=tp.topic, partition=tp.partition
         ).set(offset)
 
@@ -338,21 +464,5 @@ class PrometheusMonitor(Monitor):
         """Web server finished working on request."""
         super().on_web_request_end(app, request, response, state, view=view)
         status_code = int(state["status_code"])
-        self.http_status_codes.labels(status_code=status_code).inc()
-        self.http_latency.observe(self.ms_since(state["time_end"]))
-
-    def expose_metrics(self) -> None:
-        """Expose promethues metrics using the current aiohttp application."""
-
-        @self.app.page(self.pattern)
-        async def metrics_handler(
-            self: _web.View, request: _web.Request
-        ) -> _web.Response:
-            headers = {
-                "Content-Type": "text/plain; version=0.0.4; charset=utf-8",
-            }
-
-            return cast(
-                _web.Response,
-                Response(body=generate_latest(REGISTRY), headers=headers, status=200),
-            )
+        self._metrics.http_status_codes.labels(status_code=status_code).inc()
+        self._metrics.http_latency.observe(self.ms_since(state["time_end"]))

--- a/tests/unit/sensors/test_base.py
+++ b/tests/unit/sensors/test_base.py
@@ -66,7 +66,7 @@ def response():
     return Mock(name="response", autospec=web.Response)
 
 
-class test_Sensor:
+class TestSensor:
     @pytest.fixture
     def sensor(self, *, app):
         return Sensor()
@@ -135,7 +135,7 @@ class test_Sensor:
         assert sensor.asdict() == {}
 
 
-class test_SensorDelegate:
+class TestSensorDelegate:
     @pytest.fixture
     def sensor(self):
         return Mock(name="sensor", autospec=Sensor)

--- a/tests/unit/sensors/test_datadog.py
+++ b/tests/unit/sensors/test_datadog.py
@@ -22,7 +22,7 @@ def statsd(*, monkeypatch):
     return statsd
 
 
-class test_DatadogStatsClient:
+class TestDatadogStatsClient:
     @pytest.fixture()
     def client(self, *, dogstatsd, statsd):
         return DatadogStatsClient()
@@ -59,7 +59,7 @@ class test_DatadogStatsClient:
         )
 
 
-class test_DatadogMonitor:
+class TestDatadogMonitor:
     @pytest.fixture
     def time(self):
         timefun = Mock(name="time()")

--- a/tests/unit/sensors/test_monitor.py
+++ b/tests/unit/sensors/test_monitor.py
@@ -332,7 +332,6 @@ class TestMonitor:
         assert state["time_end"] == time()
         assert state["latency_end"] == time() - other_time
 
-    @pytest.mark.xfail(strict=True)
     def test_topic_related_sensors_are_cleared_after_rebalance(
         self, *, mon, app, message, stream, event
     ):

--- a/tests/unit/sensors/test_monitor.py
+++ b/tests/unit/sensors/test_monitor.py
@@ -15,7 +15,7 @@ from faust.types import TP, Message
 TP1 = TP("foo", 0)
 
 
-class test_Monitor:
+class TestMonitor:
     @pytest.fixture
     def time(self):
         timefun = Mock(name="time()")

--- a/tests/unit/sensors/test_prometheus.py
+++ b/tests/unit/sensors/test_prometheus.py
@@ -430,7 +430,6 @@ class TestPrometheusMonitor:
             4004,
         )
 
-    @pytest.mark.xfail(strict=True)
     def test_old_labels_are_removed_from_registry_after_rebalance(
         self,
         monitor: PrometheusMonitor,

--- a/tests/unit/sensors/test_prometheus.py
+++ b/tests/unit/sensors/test_prometheus.py
@@ -1,270 +1,448 @@
-from unittest.mock import patch
+from typing import Dict, Union
+from unittest.mock import Mock
 
 import pytest
-from mode.utils.mocks import Mock, call
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
 
 from faust import web
-from faust.exceptions import ImproperlyConfigured
-from faust.sensors.prometheus import PrometheusMonitor
-from faust.types import TP
+from faust.sensors.prometheus import FaustMetrics, PrometheusMonitor
+from faust.types import TP, AppT, EventT, StreamT, TableT
+
+Metric = Union[Counter, Gauge, Histogram]
 
 TP1 = TP("foo", 3)
+TP2 = TP("bar", 4)
+TP3 = TP("baz", 5)
+
+
+def _time() -> float:
+    return 101.1
 
 
 class TestPrometheusMonitor:
-    def time(self):
-        timefun = Mock(name="time()")
-        timefun.return_value = 101.1
-        return timefun
+    @pytest.fixture
+    def registry(self) -> CollectorRegistry:
+        return CollectorRegistry()
 
-    @patch("faust.sensors.prometheus.Histogram")
-    @patch("faust.sensors.prometheus.Gauge")
-    @patch("faust.sensors.prometheus.Counter")
-    @patch.object(PrometheusMonitor, "expose_metrics")
-    def prometheus_client(self, app, counter, gauge, histogram, time=None):
-        time = time or self.time()
+    @pytest.fixture
+    def metrics(self, registry: CollectorRegistry) -> FaustMetrics:
+        return FaustMetrics.create(registry)
 
-        return PrometheusMonitor(app, time=time)
+    @pytest.fixture
+    def app(self) -> AppT:
+        return Mock(autospec=AppT)
+
+    @pytest.fixture
+    def monitor(self, metrics: FaustMetrics) -> PrometheusMonitor:
+        return PrometheusMonitor(metrics=metrics, time=_time)
 
     @pytest.fixture()
-    def stream(self):
-        stream = Mock(name="stream")
+    def stream(self) -> StreamT:
+        stream = Mock(autospec=StreamT, name="stream")
         stream.shortlabel = "Stream: Topic: foo"
         return stream
 
     @pytest.fixture()
-    def event(self):
-        return Mock(name="event")
+    def event(self) -> EventT:
+        return Mock(autospec=EventT, name="event")
 
     @pytest.fixture()
-    def table(self):
-        table = Mock(name="table")
-        table.name = "table1"
+    def table(self) -> TableT:
+        table = Mock(autospec=TableT, name="table")
         return table
 
     @pytest.fixture()
-    def response(self):
+    def response(self) -> web.Response:
         return Mock(name="response", autospec=web.Response)
 
     @pytest.fixture()
-    def view(self):
+    def view(self) -> web.View:
         return Mock(name="view", autospec=web.View)
 
-    def test_prometheus_client_not_installed(self, app, monkeypatch):
-        monkeypatch.setattr("faust.sensors.prometheus.prometheus_client", None)
-        with pytest.raises(ImproperlyConfigured):
-            PrometheusMonitor(app)
-
-    def test_on_message_in_out(self):
+    def test_on_message_in(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics
+    ) -> None:
         message = Mock(name="message")
-        client = self.prometheus_client()
-        client.on_message_in(TP1, 400, message)
 
-        client.messages_received.inc.assert_called_once()
-        client.active_messages.inc.assert_called_once()
-        client.messages_received_per_topics.labels.assert_called_once_with(topic="foo")
+        monitor.on_message_in(TP1, 400, message)
 
-        labels = client.messages_received_per_topics_partition.labels
-        labels.assert_called_once_with(topic="foo", partition=3)
-        labels(topic="foo", partition=3).set.assert_called_once_with(400)
-
-        client.on_message_out(TP1, 400, message)
-        client.active_messages.dec.assert_called_once()
-
-    def test_on_stream_event_in_out(self, *, stream, event):
-        client = self.prometheus_client()
-        state = client.on_stream_event_in(TP1, 401, stream, event)
-
-        client.total_events.inc.assert_called_once()
-        client.total_active_events.inc.assert_called_once()
-        client.total_events_per_stream.labels.assert_called_once_with(
-            stream="stream.topic_foo.events",
+        self.assert_has_sample_value(
+            metrics.messages_received, "messages_received_total", {}, 1
+        )
+        self.assert_has_sample_value(metrics.active_messages, "active_messages", {}, 1)
+        self.assert_has_sample_value(
+            metrics.messages_received_per_topics,
+            "messages_received_per_topic_total",
+            {"topic": "foo"},
+            1,
+        )
+        self.assert_has_sample_value(
+            metrics.messages_received_per_topics_partition,
+            "messages_received_per_topics_partition",
+            {"topic": "foo", "partition": "3"},
+            400,
         )
 
-        client.on_stream_event_out(TP1, 401, stream, event, state)
-        client.total_active_events.dec.assert_called_once()
-        client.events_runtime_latency.observe.assert_called_once_with(
-            client.secs_to_ms(client.events_runtime[-1]),
+    def test_on_message_out(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics
+    ) -> None:
+        n_messages = 20
+        message = Mock(name="message", time_in=100.2)
+        metrics.active_messages.inc(n_messages)
+
+        monitor.on_message_out(TP1, 400, message)
+
+        self.assert_has_sample_value(
+            metrics.active_messages, "active_messages", {}, n_messages - 1
         )
 
-    def test_on_table_get(self, table):
-        client = self.prometheus_client()
-        client.on_table_get(table, "key")
+    def test_on_stream_event_in(
+        self,
+        monitor: PrometheusMonitor,
+        metrics: FaustMetrics,
+        stream: StreamT,
+        event: EventT,
+    ) -> None:
+        monitor.on_stream_event_in(TP1, 401, stream, event)
 
-        client.table_operations.labels.assert_called_once_with(
-            table="table.table1",
-            operation="keys_retrieved",
+        self.assert_has_sample_value(metrics.total_events, "total_events_total", {}, 1)
+        self.assert_has_sample_value(
+            metrics.total_active_events, "total_active_events", {}, 1
         )
-        client.table_operations.labels(
-            table="table.table1",
-            operation="keys_retrieved",
-        ).inc.assert_called_once()
-
-    def test_on_table_set(self, table):
-        client = self.prometheus_client()
-        client.on_table_set(table, "key", "value")
-
-        client.table_operations.labels.assert_called_once_with(
-            table="table.table1",
-            operation="keys_updated",
+        self.assert_has_sample_value(
+            metrics.total_events_per_stream,
+            "total_events_per_stream_total",
+            {"stream": "stream.topic_foo.events"},
+            1,
         )
-        client.table_operations.labels(
-            table="table.table1",
-            operation="keys_updated",
-        ).inc.assert_called_once()
 
-    def test_on_table_del(self, table):
-        client = self.prometheus_client()
-        client.on_table_del(table, "key")
+    def test_on_stream_event_out(
+        self,
+        monitor: PrometheusMonitor,
+        metrics: FaustMetrics,
+        stream: StreamT,
+        event: EventT,
+    ) -> None:
+        n_events = 25
+        state = {"time_in": 101.1, "time_out": None, "time_total": None}
+        metrics.total_active_events.inc(n_events)
 
-        client.table_operations.labels.assert_called_once_with(
-            table="table.table1",
-            operation="keys_deleted",
+        monitor.on_stream_event_out(TP1, 401, stream, event, state)
+
+        self.assert_has_sample_value(
+            metrics.total_active_events,
+            "total_active_events",
+            {},
+            n_events - 1,
         )
-        client.table_operations.labels(
-            table="table.table1",
-            operation="keys_deleted",
-        ).inc.assert_called_once()
 
-    def test_on_commit_completed(self):
+    def test_on_table_get(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics, table: TableT
+    ) -> None:
+        monitor.on_table_get(table, "key")
+
+        self.assert_has_sample_value(
+            metrics.table_operations,
+            "table_operations_total",
+            {"table": f"table.{table.name}", "operation": "keys_retrieved"},
+            1,
+        )
+
+    def test_on_table_set(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics, table: TableT
+    ) -> None:
+        monitor.on_table_set(table, "key", "value")
+
+        self.assert_has_sample_value(
+            metrics.table_operations,
+            "table_operations_total",
+            {"table": f"table.{table.name}", "operation": "keys_updated"},
+            1,
+        )
+
+    def test_on_table_del(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics, table: TableT
+    ) -> None:
+        monitor.on_table_del(table, "key")
+
+        self.assert_has_sample_value(
+            metrics.table_operations,
+            "table_operations_total",
+            {"table": f"table.{table.name}", "operation": "keys_deleted"},
+            1,
+        )
+
+    def test_on_commit_completed(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics
+    ) -> None:
         consumer = Mock(name="consumer")
-        client = self.prometheus_client()
-        state = client.on_commit_initiated(consumer)
-        client.on_commit_completed(consumer, state)
 
-        client.consumer_commit_latency.observe.assert_called_once_with(
-            client.ms_since(float(state))
+        state = monitor.on_commit_initiated(consumer)
+        monitor.on_commit_completed(consumer, state)
+
+        self.assert_has_sample_value(
+            metrics.consumer_commit_latency,
+            "consumer_commit_latency_sum",
+            {},
+            monitor.ms_since(float(state)),
         )
 
-    def test_on_send_initiated_completed(self):
+    def test_on_send_initiated_completed(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics
+    ) -> None:
         producer = Mock(name="producer")
-        client = self.prometheus_client()
-        state = client.on_send_initiated(producer, "topic1", "message", 321, 123)
 
-        client.on_send_completed(producer, state, Mock(name="metadata"))
+        state = monitor.on_send_initiated(producer, "topic1", "message", 321, 123)
+        monitor.on_send_completed(producer, state, Mock(name="metadata"))
 
-        client.total_sent_messages.inc.assert_called_once()
-        client.topic_messages_sent.labels.assert_called_once_with(topic="topic.topic1")
-        client.topic_messages_sent.labels(topic="topic.topic1").inc.assert_called_once()
-
-        client.producer_send_latency.observe.assert_called_once_with(
-            client.ms_since(float(state))
+        self.assert_has_sample_value(
+            metrics.total_sent_messages, "total_sent_messages_total", {}, 1
+        )
+        self.assert_has_sample_value(
+            metrics.topic_messages_sent,
+            "topic_messages_sent_total",
+            {"topic": "topic.topic1"},
+            1,
+        )
+        self.assert_has_sample_value(
+            metrics.producer_send_latency,
+            "producer_send_latency_sum",
+            {},
+            monitor.ms_since(float(state)),
         )
 
-        client.on_send_error(producer, KeyError("foo"), state)
+    def test_on_send_error(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics
+    ) -> None:
+        timestamp = 101.01
+        producer = Mock(name="producer")
 
-        client.total_error_messages_sent.inc.assert_called()
-        client.producer_error_send_latency.observe.assert_called_with(
-            client.ms_since(float(state))
+        monitor.on_send_error(producer, KeyError("foo"), timestamp)
+
+        self.assert_has_sample_value(
+            metrics.total_error_messages_sent,
+            "total_error_messages_sent_total",
+            {},
+            1,
+        )
+        self.assert_has_sample_value(
+            metrics.producer_error_send_latency,
+            "producer_error_send_latency_sum",
+            {},
+            monitor.ms_since(timestamp),
         )
 
-    def test_on_assignment_start_completed(self):
+    def test_on_assignment_start_completed(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics
+    ) -> None:
         assignor = Mock(name="assignor")
-        client = self.prometheus_client()
-        state = client.on_assignment_start(assignor)
-        client.on_assignment_completed(assignor, state)
 
-        client.assignment_operations.labels.assert_called_once_with(
-            operation=client.COMPLETED
+        state = monitor.on_assignment_start(assignor)
+        monitor.on_assignment_completed(assignor, state)
+
+        self.assert_has_sample_value(
+            metrics.assignment_operations,
+            "assignment_operations_total",
+            {"operation": monitor.COMPLETED},
+            1,
         )
-        client.assignment_operations.labels(
-            operation=client.COMPLETED
-        ).inc.assert_called_once()
-        client.assign_latency.observe.assert_called_once_with(
-            client.ms_since(state["time_start"])
+        self.assert_has_sample_value(
+            metrics.assign_latency,
+            "assign_latency_sum",
+            {},
+            monitor.ms_since(state["time_start"]),
         )
 
-    def test_on_assignment_start_failed(self):
+    def test_on_assignment_start_failed(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics
+    ) -> None:
         assignor = Mock(name="assignor")
-        client = self.prometheus_client()
-        state = client.on_assignment_start(assignor)
-        client.on_assignment_error(assignor, state, KeyError())
 
-        client.assignment_operations.labels.assert_called_once_with(
-            operation=client.ERROR
+        state = monitor.on_assignment_start(assignor)
+        monitor.on_assignment_error(assignor, state, KeyError("foo"))
+
+        self.assert_has_sample_value(
+            metrics.assignment_operations,
+            "assignment_operations_total",
+            {"operation": monitor.ERROR},
+            1,
         )
-        client.assignment_operations.labels(
-            operation=client.ERROR
-        ).inc.assert_called_once()
-        client.assign_latency.observe.assert_called_once_with(
-            client.ms_since(state["time_start"])
-        )
-
-    def test_on_rebalance(self):
-        app = Mock(name="app")
-        client = self.prometheus_client()
-
-        state = client.on_rebalance_start(app)
-        client.total_rebalances.inc.assert_called_once()
-
-        client.on_rebalance_return(app, state)
-        client.total_rebalances.dec.assert_called_once()
-        client.total_rebalances_recovering.inc.assert_called()
-        client.rebalance_done_consumer_latency.observe.assert_called_once_with(
-            client.ms_since(state["time_return"])
+        self.assert_has_sample_value(
+            metrics.assign_latency,
+            "assign_latency_sum",
+            {},
+            monitor.ms_since(state["time_start"]),
         )
 
-        client.on_rebalance_end(app, state)
-        client.total_rebalances_recovering.dec.assert_called()
-        client.rebalance_done_latency.observe(client.ms_since(state["time_end"]))
+    def test_on_rebalance(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics, app: AppT
+    ) -> None:
+        monitor.on_rebalance_start(app)
 
-    def test_on_web_request(self, request, response, view):
+        self.assert_has_sample_value(
+            metrics.total_rebalances, "total_rebalances", {}, 1
+        )
+
+    def test_on_rebalance_return(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics, app: AppT
+    ) -> None:
+        state = {"time_start": 99.1}
+        n_rebalances = 50
+        metrics.total_rebalances.set(n_rebalances)
+
+        monitor.on_rebalance_return(app, state)
+
+        self.assert_has_sample_value(
+            metrics.total_rebalances, "total_rebalances", {}, n_rebalances - 1
+        )
+        self.assert_has_sample_value(
+            metrics.total_rebalances_recovering,
+            "total_rebalances_recovering",
+            {},
+            1,
+        )
+        self.assert_has_sample_value(
+            metrics.rebalance_done_consumer_latency,
+            "rebalance_done_consumer_latency_sum",
+            {},
+            monitor.ms_since(state["time_return"]),
+        )
+
+    def test_on_rebalance_end(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics, app: AppT
+    ) -> None:
+        state = {"time_start": 99.2}
+        n_rebalances = 12
+        metrics.total_rebalances_recovering.set(n_rebalances)
+
+        monitor.on_rebalance_end(app, state)
+
+        self.assert_has_sample_value(
+            metrics.total_rebalances_recovering,
+            "total_rebalances_recovering",
+            {},
+            n_rebalances - 1,
+        )
+        self.assert_has_sample_value(
+            metrics.rebalance_done_latency,
+            "rebalance_done_latency_sum",
+            {},
+            monitor.ms_since(state["time_end"]),
+        )
+
+    def test_on_web_request(
+        self,
+        monitor: PrometheusMonitor,
+        metrics: FaustMetrics,
+        app: AppT,
+        request: web.Request,
+        response: web.Response,
+        view: web.View,
+    ) -> None:
         response.status = 404
-        self.assert_on_web_request(request, response, view, expected_status=404)
-
-    def test_on_web_request_none_response(self, request, view):
-        self.assert_on_web_request(request, None, view, expected_status=500)
-
-    def assert_on_web_request(self, request, response, view, expected_status):
-        app = Mock(name="app")
-        client = self.prometheus_client()
-        state = client.on_web_request_start(app, request, view=view)
-        client.on_web_request_end(app, request, response, state, view=view)
-
-        client.http_status_codes.labels.assert_called_with(status_code=expected_status)
-        client.http_status_codes.labels(status_code=expected_status).inc.assert_called()
-        client.http_latency.observe.assert_called_with(
-            client.ms_since(state["time_end"])
+        self.assert_on_web_request(
+            monitor, metrics, app, request, response, view, expected_status=404
         )
 
-    def test_count(self):
-        client = self.prometheus_client()
-        client.count("metric_name", count=3)
-
-        client.count_metrics_by_name.labels.assert_called_once_with(
-            metric="metric_name"
-        )
-        client.count_metrics_by_name.labels(
-            metric="metric_name"
-        ).inc.assert_called_once_with(3)
-
-    def test_on_tp_commit(self):
-        offsets = {
-            TP("foo", 0): 1001,
-            TP("foo", 1): 2002,
-            TP("bar", 3): 3003,
-        }
-        client = self.prometheus_client()
-
-        client.on_tp_commit(offsets)
-        client.topic_partition_offset_commited.labels.assert_has_calls(
-            [
-                call(topic="foo", partition=0),
-                call().set(1001),
-                call(topic="foo", partition=1),
-                call().set(2002),
-                call(topic="bar", partition=3),
-                call().set(3003),
-            ]
+    def test_on_web_request_none_response(
+        self,
+        monitor: PrometheusMonitor,
+        metrics: FaustMetrics,
+        app: AppT,
+        request: web.Request,
+        view: web.View,
+    ) -> None:
+        self.assert_on_web_request(
+            monitor, metrics, app, request, None, view, expected_status=500
         )
 
-    def test_track_tp_end_offsets(self):
-        client = self.prometheus_client()
-        client.track_tp_end_offset(TP("foo", 0), 4004)
+    def assert_on_web_request(
+        self,
+        monitor: PrometheusMonitor,
+        metrics: FaustMetrics,
+        app: AppT,
+        request: web.Request,
+        response: web.Response,
+        view: web.View,
+        expected_status: int,
+    ) -> None:
+        state = monitor.on_web_request_start(app, request, view=view)
+        monitor.on_web_request_end(app, request, response, state, view=view)
 
-        client.topic_partition_end_offset.labels.assert_called_once_with(
-            topic="foo", partition=0
+        self.assert_has_sample_value(
+            metrics.http_status_codes,
+            "http_status_codes_total",
+            {"status_code": str(expected_status)},
+            1,
         )
-        client.topic_partition_end_offset.labels(
-            topic="foo", partition=0
-        ).set.assert_called_once_with(4004)
+        self.assert_has_sample_value(
+            metrics.http_latency,
+            "http_latency_sum",
+            {},
+            monitor.ms_since(state["time_end"]),
+        )
+
+    def test_count(self, monitor: PrometheusMonitor, metrics: FaustMetrics) -> None:
+        monitor.count("metric_name", count=3)
+
+        self.assert_has_sample_value(
+            metrics.count_metrics_by_name,
+            "metrics_by_name",
+            {"metric": "metric_name"},
+            3,
+        )
+
+    def test_on_tp_commit(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics
+    ) -> None:
+        offsets = {TP("foo", 0): 1001, TP("foo", 1): 2002, TP("bar", 3): 3003}
+
+        monitor.on_tp_commit(offsets)
+
+        self.assert_has_sample_value(
+            metrics.topic_partition_offset_commited,
+            "topic_partition_offset_commited",
+            {"topic": "foo", "partition": "0"},
+            1001,
+        )
+        self.assert_has_sample_value(
+            metrics.topic_partition_offset_commited,
+            "topic_partition_offset_commited",
+            {"topic": "foo", "partition": "1"},
+            2002,
+        )
+        self.assert_has_sample_value(
+            metrics.topic_partition_offset_commited,
+            "topic_partition_offset_commited",
+            {"topic": "bar", "partition": "3"},
+            3003,
+        )
+
+    def test_track_tp_end_offsets(
+        self, monitor: PrometheusMonitor, metrics: FaustMetrics
+    ) -> None:
+        monitor.track_tp_end_offset(TP("foo", 0), 4004)
+
+        self.assert_has_sample_value(
+            metrics.topic_partition_end_offset,
+            "topic_partition_end_offset",
+            {"topic": "foo", "partition": "0"},
+            4004,
+        )
+
+    def assert_has_sample_value(
+        self, metric: Metric, name: str, labels: Dict[str, str], value: int
+    ) -> None:
+        samples = metric.collect()[0].samples
+        assert any(
+            sample.name == name and sample.labels == labels and sample.value == value
+            for sample in samples
+        )
+
+    def assert_doesnt_have_sample_values(
+        self, metric: Metric, name: str, labels: Dict[str, str]
+    ) -> None:
+        samples = [
+            sample for sample in metric.collect()[0].samples if sample.name == name
+        ]
+        assert samples == []

--- a/tests/unit/sensors/test_prometheus.py
+++ b/tests/unit/sensors/test_prometheus.py
@@ -136,7 +136,6 @@ class TestPrometheusMonitor:
             n_events - 1,
         )
 
-    @pytest.mark.xfail(strict=True)
     def test_on_stream_event_out_does_not_measure_latency_without_state(
         self,
         monitor: PrometheusMonitor,

--- a/tests/unit/sensors/test_prometheus.py
+++ b/tests/unit/sensors/test_prometheus.py
@@ -136,6 +136,20 @@ class TestPrometheusMonitor:
             n_events - 1,
         )
 
+    @pytest.mark.xfail(strict=True)
+    def test_on_stream_event_out_does_not_measure_latency_without_state(
+        self,
+        monitor: PrometheusMonitor,
+        metrics: FaustMetrics,
+        stream: StreamT,
+        event: EventT,
+    ) -> None:
+        monitor.on_stream_event_out(TP1, 401, stream, event, state=None)
+
+        self.assert_doesnt_have_sample_values(
+            metrics.events_runtime_latency, "events_runtime_latency_total", {}
+        )
+
     def test_on_table_get(
         self, monitor: PrometheusMonitor, metrics: FaustMetrics, table: TableT
     ) -> None:

--- a/tests/unit/sensors/test_prometheus.py
+++ b/tests/unit/sensors/test_prometheus.py
@@ -11,7 +11,7 @@ from faust.types import TP
 TP1 = TP("foo", 3)
 
 
-class test_PrometheusMonitor:
+class TestPrometheusMonitor:
     def time(self):
         timefun = Mock(name="time()")
         timefun.return_value = 101.1

--- a/tests/unit/sensors/test_statsd.py
+++ b/tests/unit/sensors/test_statsd.py
@@ -9,7 +9,7 @@ from faust.types import TP
 TP1 = TP("foo", 3)
 
 
-class test_StatsdMonitor:
+class TestStatsdMonitor:
     @pytest.fixture
     def time(self):
         timefun = Mock(name="time()")


### PR DESCRIPTION
Fix for improper sensors after rebalancing.

I use faust-streaming with prometheus sensors. When my workers get rebalanced they report metrics for topics and/or topic-partitions they do not handle anymore and I end up with multiple metrics in Prometheus for the same labels, some of them stalled.