### PR TITLE
Fix dropped messages when topic backpressure is enabled (#88)

### DIFF
--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -692,7 +692,11 @@ class Consumer(Service, ConsumerT):
             for tp, record in records_it:
                 if not self.flow_active:
                     break
-                if active_partitions is None or tp in active_partitions:
+                if (
+                    active_partitions is None
+                    or tp in active_partitions
+                    or tp in self._buffered_partitions
+                ):
                     highwater_mark = self.highwater(tp)
                     self.app.monitor.track_tp_end_offset(tp, highwater_mark)
                     # convert timestamp to seconds from int milliseconds.

--- a/tests/unit/transport/test_consumer.py
+++ b/tests/unit/transport/test_consumer.py
@@ -416,7 +416,7 @@ class MyConsumer(MockedConsumerAbstractMethods, Consumer):
         super().__init__(*args, **kwargs)
 
 
-class test_Consumer:
+class TestConsumer:
     @pytest.fixture
     def callback(self):
         return Mock(name="callback")
@@ -526,6 +526,38 @@ class test_Consumer:
         ]
 
     @pytest.mark.asyncio
+    async def test_getmany_buffered(self, *, consumer):
+        def to_message(tp, record):
+            return record
+
+        consumer._to_message = to_message
+        self._setup_records(
+            consumer,
+            active_partitions={TP1},
+            buffered_partitions={TP2},
+            records={
+                TP1: ["A", "B", "C"],
+                TP2: ["D", "E", "F", "G"],
+                TP3: ["H", "I", "J"],
+            },
+        )
+        assert not consumer.should_stop
+        consumer.flow_active = False
+        consumer.can_resume_flow.set()
+        assert [a async for a in consumer.getmany(1.0)] == []
+        assert not consumer.should_stop
+        consumer.flow_active = True
+        assert [a async for a in consumer.getmany(1.0)] == [
+            (TP1, "A"),
+            (TP2, "D"),
+            (TP1, "B"),
+            (TP2, "E"),
+            (TP1, "C"),
+            (TP2, "F"),
+            (TP2, "G"),
+        ]
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "client_only",
         [
@@ -563,10 +595,16 @@ class test_Consumer:
         assert ret == ({}, set())
 
     def _setup_records(
-        self, consumer, active_partitions, records=None, flow_active=True
+        self,
+        consumer,
+        active_partitions,
+        records=None,
+        flow_active=True,
+        buffered_partitions=None,
     ):
         consumer.flow_active = flow_active
         consumer._active_partitions = active_partitions
+        consumer._buffered_partitions = buffered_partitions or set()
         consumer._getmany = AsyncMock(
             return_value={} if records is None else records,
         )


### PR DESCRIPTION

## Description

Fixes #88 

Consumer.getmany() should continue to yield messages from the TopicBuffer as long as the topic is in available_partitions or buffered_partitions