### PR TITLE
allow only positive offsets to dictate recovery

### DIFF
--- a/faust/tables/recovery.py
+++ b/faust/tables/recovery.py
@@ -751,7 +751,7 @@ class Recovery(Service):
             # the aiokafka consumer position and draining of the queue
             if timeout and self.app.in_transaction and timeout_count > 1:
                 await detect_aborted_tx()
-            if not self.active_remaining_total() and self.in_recovery:
+            if not self.need_recovery() and self.in_recovery:
                 # apply anything stuck in the buffers
                 self.flush_buffers()
                 self._set_recovery_ended()


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

If the offsets are not present in Kafka(local offsets > offsets in kafka) the worker enters in endless recovery loop.

