### PR TITLE
fix agents with multiple topics

### DIFF
--- a/faust/agents/agent.py
+++ b/faust/agents/agent.py
@@ -1,6 +1,5 @@
 """Agent implementation."""
 import asyncio
-import sys
 import typing
 from contextlib import suppress
 from contextvars import ContextVar
@@ -659,23 +658,7 @@ class Agent(AgentT, Service):
         else:
             # agent yields and is an AsyncIterator so we have to consume it.
             coro = self._slurp(aref, aiter(aref))
-        req_version = (3, 8)
-        cur_version = sys.version_info
-        if cur_version >= req_version:
-            if isinstance(self.channel, TopicT):
-                name = self.channel.get_topic_name()
-            else:
-                name = "channel"
-            task = asyncio.Task(
-                self._execute_actor(coro, aref),
-                loop=self.loop,
-                name=f"{str(aref)}-{name}",
-            )
-        else:
-            task = asyncio.Task(
-                self._execute_actor(coro, aref),
-                loop=self.loop,
-            )
+        task = asyncio.Task(self._execute_actor(coro, aref), loop=self.loop)
         task._beacon = beacon  # type: ignore
         aref.actor_task = task
         self._actors.add(aref)


### PR DESCRIPTION
## Description

A bug was introduced in https://github.com/faust-streaming/faust/commit/fda7e5264a4e19321e286d3151a0e0bb56ee5545
where an asyncio task was using a topic name as its identifier. The
change isn't compatible with the Topic implementation where ValueError
is thrown for getting topic name when multiple names are set.