### PR TITLE
#113 - fix datadog and statsd sensor - on_stream_event_out() can now be called with no state

### DIFF
--- a/faust/sensors/datadog.py
+++ b/faust/sensors/datadog.py
@@ -181,11 +181,12 @@ class DatadogMonitor(Monitor):
         super().on_stream_event_out(tp, offset, stream, event, state)
         labels = self._format_label(tp, stream)
         self.client.decrement("events_active", labels=labels)
-        self.client.timing(
-            "events_runtime",
-            self.secs_to_ms(self.events_runtime[-1]),
-            labels=labels,
-        )
+        if state is not None:
+            self.client.timing(
+                "events_runtime",
+                self.secs_to_ms(self.events_runtime[-1]),
+                labels=labels,
+            )
 
     def on_message_out(self, tp: TP, offset: int, message: Message) -> None:
         """Call when message is fully acknowledged and can be committed."""

--- a/faust/sensors/statsd.py
+++ b/faust/sensors/statsd.py
@@ -104,9 +104,12 @@ class StatsdMonitor(Monitor):
         """Call when stream is done processing an event."""
         super().on_stream_event_out(tp, offset, stream, event, state)
         self.client.decr("events_active", rate=self.rate)
-        self.client.timing(
-            "events_runtime", self.secs_to_ms(self.events_runtime[-1]), rate=self.rate
-        )
+        if state is not None:
+            self.client.timing(
+                "events_runtime",
+                self.secs_to_ms(self.events_runtime[-1]),
+                rate=self.rate,
+            )
 
     def on_message_out(self, tp: TP, offset: int, message: Message) -> None:
         """Call when message is fully acknowledged and can be committed."""


### PR DESCRIPTION
## Description

This is a quick fix for #113 . Prometheus-related code already has this if-statement:
```python

class PrometheusMonitor(Monitor):
    ...
    def on_stream_event_out(self, tp: TP,  offset: int, stream: StreamT, event: EventT, state: typing.Dict = None) -> None:
        """Call when stream is done processing an event."""
        super().on_stream_event_out(tp, offset, stream, event, state)
        self._metrics.total_active_events.dec()
        if state is not None:
            self._metrics.events_runtime_latency.observe(
                self.secs_to_ms(self.events_runtime[-1])
            )
```
but it's missing in `StatsdMonitor` and `DatadogMonitor`.

Eventually streams with manual acknowledgement (`.noack()`) should also be able to provide `state` in `.on_stream_event_out()` methods but that requires more complex changes so I focused on a quick fix in here.
