### PR TITLE
Fix partition from message for globaltables or tables that use partitioner

### DIFF
--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -289,7 +289,8 @@ class Store(base.SerializedStore):
 
     def _get(self, key: bytes) -> Optional[bytes]:
         event = current_event()
-        if event is not None:
+        partition_from_message = event is not None and not self.table.is_global and not self.table.use_partitioner
+        if partition_from_message:
             partition = event.message.partition
             db = self._db_for_partition(partition)
             value = db.get(key)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
 #aiokafka==0.7.0
-git+https://github.com/smaxtec/aiokafka-1@0.7.1#egg=aiokafka
+git+https://github.com/smaxtec/aiokafka-1@v0.7.1#egg=aiokafka
 click>=6.7,<8.0
 colorclass>=2.2,<3.0
 mode-streaming==0.1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
-#aiokafka==0.7.0
+aiokafka==0.7.0
 #git+https://github.com/smaxtec/aiokafka-1@v0.7.1#egg=aiokafka
 click>=6.7,<8.0
 colorclass>=2.2,<3.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
 #aiokafka==0.7.0
-git+https://github.com/smaxtec/aiokafka-1@v0.7.1#egg=aiokafka
+#git+https://github.com/smaxtec/aiokafka-1@v0.7.1#egg=aiokafka
 click>=6.7,<8.0
 colorclass>=2.2,<3.0
 mode-streaming==0.1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
-aiokafka==0.7.0
+#aiokafka==0.7.0
+git+https://github.com/smaxtec/aiokafka-1@master#egg=aiokafka
 click>=6.7,<8.0
 colorclass>=2.2,<3.0
 mode-streaming==0.1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
 #aiokafka==0.7.0
-git+https://github.com/smaxtec/aiokafka-1@master#egg=aiokafka
+git+https://github.com/smaxtec/aiokafka-1@0.7.1#egg=aiokafka
 click>=6.7,<8.0
 colorclass>=2.2,<3.0
 mode-streaming==0.1.0


### PR DESCRIPTION
## Description

At the moment when using global tables or use_partitioner for a table and rocksdb store a get won't return the value when the partition of the key to be retrieved is not the same (in terms of the partitioner) as the partition of the event that led to storing the key. This is a (imperformant) fix that in my understanding always searches in all partitions of rocksdb for the key when using global table or use_partitioner.
