### PR TITLE
fix rocksdb for use with global tables or tables that use_partitioner

### DIFF
--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -290,9 +290,9 @@ class Store(base.SerializedStore):
     def _get(self, key: bytes) -> Optional[bytes]:
         event = current_event()
         partition_from_message = (
-            event is not None and
-            not self.table.is_global and
-            not self.table.use_partitioner
+            event is not None
+            and not self.table.is_global
+            and not self.table.use_partitioner
         )
         if partition_from_message:
             partition = event.message.partition

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -289,9 +289,11 @@ class Store(base.SerializedStore):
 
     def _get(self, key: bytes) -> Optional[bytes]:
         event = current_event()
-        partition_from_message = (event is not None and
-                                 not self.table.is_global and
-                                 not self.table.use_partitioner)
+        partition_from_message = (
+            event is not None and
+            not self.table.is_global and
+            not self.table.use_partitioner
+        )
         if partition_from_message:
             partition = event.message.partition
             db = self._db_for_partition(partition)

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -289,7 +289,10 @@ class Store(base.SerializedStore):
 
     def _get(self, key: bytes) -> Optional[bytes]:
         event = current_event()
-        if event is not None:
+        partition_from_message = (event is not None and
+                                 not self.table.is_global and
+                                 not self.table.use_partitioner)
+        if partition_from_message:
             partition = event.message.partition
             db = self._db_for_partition(partition)
             value = db.get(key)


### PR DESCRIPTION
## Description
At the moment when using global tables or use_partitioner for a table and rocksdb store a get won't return the value when the partition of the key to be retrieved is not the same (in terms of the partitioner) as the partition of the event that led to storing the key. This is a (imperformant) fix that in my understanding always searches in all partitions of rocksdb for the key when using global table or use_partitioner.
