### PR TITLE
Calling window close callback after popping the value from store

### DIFF
--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -375,8 +375,7 @@ class Collection(Service, CollectionT):
                 if keys_to_remove:
                     for key in keys_to_remove:
                         value = self.data.pop(key, None)
-                        if key[1][0] > self.last_closed_window:
-                            await self.on_window_close(key, value)
+                        await self.on_window_close(key, value)
                     self.last_closed_window = max(
                         self.last_closed_window,
                         max(key[1][0] for key in keys_to_remove),


### PR DESCRIPTION
## Description
In the current case, if a window is to be closed the start timestamp of the current window is checked against `last_closed_window`.
```python
if keys_to_remove:
    for key in keys_to_remove:
        value = self.data.pop(key, None)
        if key[1][0] > self.last_closed_window:
            await self.on_window_close(key, value)
    self.last_closed_window = max(
        self.last_closed_window,
        max(key[1][0] for key in keys_to_remove),
    )
```

Which means in this case if we are using `relative_to_field` for a Windowed Table and event comes with some old timestamp which is lesser than `last_closed_window`, then the `value` would already be popped but the on_window_close wouldn't be called. 

Ideally if window is closed we should be calling the on_window_close callback