### PR TITLE
enable testing against python 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
       # for example if a test fails only when Cython is enabled
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
         use-cython: ["true", "false"]
     env:
       USE_CYTHON: ${{ matrix.use-cython }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = 3.8,3.7,3.6,flake8,apicheck,configcheck,typecheck,docstyle,bandit,spell
+envlist = 3.9,3.8,3.7,3.6,flake8,apicheck,configcheck,typecheck,docstyle,bandit,spell
 
 [testenv]
 deps=
@@ -17,6 +17,7 @@ recreate = False
 commands = py.test --random-order --open-files -xvv --cov=faust tests/unit tests/functional tests/integration tests/meticulous/ tests/regression
 
 basepython =
+    3.9,flake8,apicheck,linkcheck,configcheck,typecheck,docstyle,bandit,spell: python3.9
     3.8,flake8,apicheck,linkcheck,configcheck,typecheck,docstyle,bandit,spell: python3.8
     3.7: python3.7
     3.6: python3.6


### PR DESCRIPTION
## Description

Python 3.9 has been out for a while.  We should test against it to make sure it's supported.