### PR TITLE
bumped dependency version: aiokafka==0.7.1

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
-aiokafka==0.7.1
+aiokafka>=0.7.1,<0.8.0
 click>=6.7,<8.0
 colorclass>=2.2,<3.0
 mode-streaming==0.1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
-aiokafka==0.7.0
+aiokafka==0.7.1
 click>=6.7,<8.0
 colorclass>=2.2,<3.0
 mode-streaming==0.1.0


### PR DESCRIPTION
## Description

https://github.com/aio-libs/aiokafka/blob/master/CHANGES.rst#071-2021-06-04
https://pypi.org/project/aiokafka/0.7.1/#files

This version fixes https://github.com/aio-libs/aiokafka/issues/727
```
Make sure generation and member id are correct after (re)joining group. (issue #727 and pr #747 by @vangheem)
```