### PR TITLE
Use faust-streaming-rocksdb in rocksdb.txt requirements file

### DIFF
--- a/requirements/extras/rocksdb.txt
+++ b/requirements/extras/rocksdb.txt
@@ -1,1 +1,1 @@
-python-rocksdb>=0.6.7
+faust-streaming-rocksdb>=0.8.0


### PR DESCRIPTION
## Description

This updates requirements/extras/rocksdb.txt to use faust-streaming-rocksdb instead of python-rocksdb as mentioned in #121 
