### PR TITLE
fix for reassign Table Keys faust-streaming#171

### DIFF
--- a/faust/stores/memory.py
+++ b/faust/stores/memory.py
@@ -31,7 +31,7 @@ class Store(base.Store):
             self._create_batch_iterator(to_delete.add, to_key, to_value, batch)
         )
         for key in to_delete:
-            # If the key was assigned a value again at a later time, it will not be deleted.
+            # If the key was assigned a value again, it will not be deleted.
             if not self.data[key]:
                 delete_key(key, None)
 

--- a/faust/stores/memory.py
+++ b/faust/stores/memory.py
@@ -31,7 +31,9 @@ class Store(base.Store):
             self._create_batch_iterator(to_delete.add, to_key, to_value, batch)
         )
         for key in to_delete:
-            delete_key(key, None)
+            # If the key was assigned a value again at a later time, it will not be deleted.
+            if not self.data[key]:
+                delete_key(key, None)
 
     def _create_batch_iterator(
         self,
@@ -45,7 +47,6 @@ class Store(base.Store):
             # to delete keys in the table we set the raw value to None
             if event.message.value is None:
                 mark_as_delete(key)
-                continue
             yield key, to_value(event.value)
 
     def persisted_offset(self, tp: TP) -> Optional[int]:

--- a/tests/unit/stores/test_memory.py
+++ b/tests/unit/stores/test_memory.py
@@ -33,6 +33,15 @@ class Test_Store:
 
         assert to_key() not in store.data
 
+    def test_apply_changelog_batch__deletes_key_and_reassign_it(self, *, store):
+        self.test_apply_changelog_batch__deletes_key_for_None_value(store=store)
+
+        events = [self.mock_event(value=value) for value in ("v1", None, "v2")]
+        to_key, to_value = self.mock_to_key_value(events[0])
+
+        store.apply_changelog_batch(events, to_key=to_key, to_value=to_value)
+        assert to_key() in store.data
+
     def mock_event_to_key_value(self, key=b"key", value=b"value"):
         event = self.mock_event(key=key, value=value)
         to_key, to_value = self.mock_to_key_value(event)


### PR DESCRIPTION
## Description

(Fixes #171)
When a key is removed from a table with table.pop(), a changelog entry is sent with a raw null value.

Before this change, on Table recovery, once a key was set to the raw null value, it would be deleted after iterating over the entire Changelog topic.
Now, before deletion, the value for this key is checked to see if it is really null. Otherwise it was assigned to a new value at a later time and will not be deleted
