### PR TITLE
fixes #197

### DIFF
--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -1389,7 +1389,7 @@ class App(AppT, Service):
         self.client_only = True
         await self.maybe_start()
         self.consumer.stop_flow()
-        await self.topics.wait_for_subscriptions()
+        await self.topics.maybe_wait_for_subscriptions()
         await self.topics.on_client_only_start()
         self.consumer.resume_flow()
         self.flow_control.resume()


### PR DESCRIPTION
## Description

Fixes #197 

`start_client` was getting stuck on calling `await self.topics.wait_for_subscriptions()`. In client only mode would there ever be valid subscriptions? If not, the changed line could be removed entirely