### PR TITLE
Remove outdated colorclass library

### DIFF
--- a/docs/userguide/cli.rst
+++ b/docs/userguide/cli.rst
@@ -122,7 +122,6 @@ Example:
     --json / --no-json              Prefer data to be emitted in json format.
     -D, --datadir DIRECTORY         Directory to keep application state.
     -W, --workdir DIRECTORY         Working directory to change to after start.
-    --no-color / --color            Enable colors in output.
     --debug / --no-debug            Enable debugging output, and the blocking
                                     detector.
     -q, --quiet / --no-quiet        Silence output to <stdout>/<stderr>.

--- a/faust/cli/agents.py
+++ b/faust/cli/agents.py
@@ -40,9 +40,9 @@ class agents(AppCommand):
     def agent_to_row(self, agent: AgentT) -> Sequence[str]:
         """Convert agent fields to terminal table row."""
         return [
-            self.bold_tail(self._name(agent)),
+            self._name(agent),
             self._topic(agent),
-            self.dark(self._help(agent)),
+            self._help(agent),
         ]
 
     def _name(self, agent: AgentT) -> str:

--- a/faust/cli/model.py
+++ b/faust/cli/model.py
@@ -45,7 +45,7 @@ class model(AppCommand):
         self.say(
             self.tabulate(
                 self.model_fields(model),
-                headers=[h for h in self.headers],
+                headers=self.headers,
                 title=self._name(model),
                 wrap_last_row=False,
             )

--- a/faust/cli/model.py
+++ b/faust/cli/model.py
@@ -45,7 +45,7 @@ class model(AppCommand):
         self.say(
             self.tabulate(
                 self.model_fields(model),
-                headers=[self.bold(h) for h in self.headers],
+                headers=[h for h in self.headers],
                 title=self._name(model),
                 wrap_last_row=False,
             )
@@ -69,7 +69,7 @@ class model(AppCommand):
         return [
             field.field,
             self._type(field.type),
-            self.dark("*" if field.required else repr(field.default)),
+            "*" if field.required else repr(field.default),
         ]
 
     def _type(self, typ: Any) -> str:
@@ -78,8 +78,8 @@ class model(AppCommand):
     def model_to_row(self, model: Type[ModelT]) -> Sequence[str]:
         """Convert model to terminal table row."""
         return [
-            self.bold_tail(self._name(model)),
-            self.dark(self._help(model)),
+            self._name(model),
+            self._help(model),
         ]
 
     def _name(self, model: Type[ModelT]) -> str:

--- a/faust/cli/models.py
+++ b/faust/cli/models.py
@@ -43,8 +43,8 @@ class models(AppCommand):
     def model_to_row(self, model: Type[ModelT]) -> Sequence[str]:
         """Convert model fields to terminal table columns."""
         return [
-            self.bold_tail(self._name(model)),
-            self.dark(self._help(model)),
+            self._name(model),
+            self._help(model),
         ]
 
     def _name(self, model: Type[ModelT]) -> str:

--- a/faust/cli/tables.py
+++ b/faust/cli/tables.py
@@ -14,7 +14,7 @@ class tables(AppCommand):
         self.say(
             self.tabulate(
                 [
-                    (self.bold(table.name), self.dark(table.help or DEFAULT_TABLE_HELP))
+                    (table.name, table.help or DEFAULT_TABLE_HELP)
                     for table in self.app.tables.values()
                 ],
                 title=self.title,

--- a/faust/cli/worker.py
+++ b/faust/cli/worker.py
@@ -115,7 +115,7 @@ class worker(AppCommand):
 
     def _format_banner_table(self, data: TableDataT) -> str:
         table = self.table(
-            [(self.bold(x), str(y)) for x, y in data],
+            [(x, str(y)) for x, y in data],
             title=self._banner_title(),
         )
         table.inner_heading_row_border = False
@@ -176,7 +176,7 @@ class worker(AppCommand):
 
     def faust_ident(self) -> str:
         """Return Faust version information as ANSI string."""
-        return self.color("hiblue", f"{FAUST} v{faust_version}")
+        return f"{FAUST} v{faust_version}"
 
     def platform(self) -> str:
         """Return platform identifier as ANSI string."""

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,6 @@ aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
 aiokafka>=0.7.1,<0.8.0
 click>=6.7,<8.0
-colorclass>=2.2,<3.0
 mode-streaming==0.1.0
 opentracing>=1.3.0,<=2.4.0
 terminaltables>=3.1,<4.0

--- a/tests/integration/cli/test_agents.py
+++ b/tests/integration/cli/test_agents.py
@@ -22,12 +22,6 @@ def test_tabulated(faust):
     assert b"@app.mul" in stdout
 
 
-def test_colors(faust_color):
-    exitcode, stdout, stderr = faust_color("agents", "--local")
-    assert not exitcode
-    assert b"@app.mul" in stdout
-
-
 def test_json_no_local(faust_json):
     exitcode, agents, stderr = faust_json("agents")
     assert not exitcode

--- a/tests/integration/cli/test_model.py
+++ b/tests/integration/cli/test_model.py
@@ -13,10 +13,6 @@ class Test_Arena:
         assert not exitcode
         assert b"typing.List" in stdout
 
-    def test_colors(self, faust_color):
-        exitcode, stdout, stderr = faust_color("model", "app.Arena")
-        assert b"typing.List" in stdout
-
 
 class Test_Point:
     def test_json(self, faust_json):
@@ -30,10 +26,5 @@ class Test_Point:
 
     def test_tabulated(self, faust):
         exitcode, stdout, stderr = faust("model", "app.Point")
-        assert not exitcode
-        assert b"int" in stdout
-
-    def test_colors(self, faust_color):
-        exitcode, stdout, stderr = faust_color("model", "app.Point")
         assert not exitcode
         assert b"int" in stdout

--- a/tests/integration/cli/test_models.py
+++ b/tests/integration/cli/test_models.py
@@ -20,12 +20,6 @@ def test_tabulated(faust):
     assert b"Arena" in stdout
 
 
-def test_colors(faust_color):
-    exitcode, stdout, stderr = faust_color("models", "--builtins")
-    assert not exitcode
-    assert b"Point" in stdout
-
-
 def test_json_no_local(faust_json):
     exitcode, models, stderr = faust_json("models")
     assert not exitcode

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,10 +29,8 @@ CommandReturns = Tuple[int, str, str]
 
 
 def _create_faust_cli(
-    executable: Path, *partial_args: str, color: bool = False, json: bool = False
+    executable: Path, *partial_args: str, json: bool = False
 ) -> Callable[..., CommandReturns]:
-    if not color:
-        partial_args += ("--no-color",)
     if json:
         partial_args += ("--json",)
 
@@ -62,8 +60,3 @@ def faust(main_path: Path) -> Callable[..., CommandReturns]:
 @pytest.fixture
 def faust_json(main_path: Path):
     return _create_faust_cli(main_path, json=True)
-
-
-@pytest.fixture
-def faust_color(main_path: Path) -> Callable[..., CommandReturns]:
-    return _create_faust_cli(main_path, color=True)

--- a/tests/unit/cli/test_base.py
+++ b/tests/unit/cli/test_base.py
@@ -201,7 +201,6 @@ def Test__prepare_cli():
             workdir="/foo",
             datadir="/data",
             json=True,
-            no_color=False,
             loop="foo",
         )
 
@@ -211,7 +210,6 @@ def Test__prepare_cli():
         assert state.workdir == "/foo"
         assert state.datadir == "/data"
         assert state.json
-        assert not state.no_color
         assert state.loop == "foo"
 
         root.side_effects = True
@@ -228,7 +226,6 @@ def Test__prepare_cli():
                             workdir="/foo",
                             datadir="/data",
                             json=False,
-                            no_color=False,
                             loop="foo",
                         )
                         chdir.assert_called_with(Path("/foo").absolute())
@@ -242,7 +239,6 @@ def Test__prepare_cli():
                             workdir="/foo",
                             datadir="/data",
                             json=True,
-                            no_color=False,
                             loop="foo",
                         )
                         dac.assert_called_once_with()
@@ -256,7 +252,6 @@ def Test__prepare_cli():
                             workdir="/foo",
                             datadir="/data",
                             json=False,
-                            no_color=True,
                             loop="foo",
                         )
                         eac.assert_not_called()
@@ -269,7 +264,6 @@ def Test__prepare_cli():
                             workdir=None,
                             datadir=None,
                             json=False,
-                            no_color=True,
                             loop="foo",
                         )
     finally:
@@ -425,18 +419,6 @@ class Test_Command:
             t = command.table(data, title="foo")
             assert t is table.return_value
             table.assert_called_once_with(data, title="foo", target=sys.stdout)
-
-    def test_color(self, *, command):
-        assert command.color("blue", "text")
-
-    def test_dark(self, *, command):
-        assert command.dark("text")
-
-    def test_bold(self, *, command):
-        assert command.bold("text")
-
-    def test_bold_tail(self, *, command):
-        assert command.bold_tail("foo.bar.baz")
 
     def test_table_wrap(self, *, command):
         table = command.table([["A", "B", "C"]])


### PR DESCRIPTION
## Description

removes `colorclass` requirement and uses of the library.  That library has not been updated since 2016 and no longer works with python-3.10.  There are other options, but they don't easily fit into the faust wrappers around it.  Better to remove it and if necessary, add in a different library later on.