### PR TITLE
Fix worker default web_host to be None

### DIFF
--- a/faust/cli/worker.py
+++ b/faust/cli/worker.py
@@ -55,7 +55,7 @@ class worker(AppCommand):
         option(
             "--web-host",
             "-h",
-            default=socket.gethostname(),
+            default=None,
             type=str,
             help=f"Canonical host name for the web server " f"(default: {WEB_BIND})",
         ),
@@ -86,7 +86,7 @@ class worker(AppCommand):
         with_web: bool,
         web_port: Optional[int],
         web_bind: Optional[str],
-        web_host: str,
+        web_host: Optional[str],
         web_transport: URL,
         **kwargs: Any,
     ) -> None:


### PR DESCRIPTION
## Description

This pull request only removes the default web_host value when starting the worker from the CLI. This way, if web_host is not provider in the CLI, the app will use the default web_host which is socket.gethostname() as set in [settings.py](https://github.com/faust-streaming/faust/blob/9385c8166256bc85c5c4b985fab6b749d070ba68/faust/types/settings/settings.py#L1831)

Not sure why this was kept this way, maybe it's something that was forgotten when moving the configuration to settings.py

Config order of precendence:
1) Worker CLI config (--web_host, --web_port)
2) Apps init config
3) Default config (settings.py)