### PR TITLE
Fix Recovery._resume_streams

### DIFF
--- a/faust/tables/recovery.py
+++ b/faust/tables/recovery.py
@@ -304,10 +304,6 @@ class Recovery(Service):
         app = self.app
         consumer = app.consumer
         await app.on_rebalance_complete.send()
-        # Resume partitions and start fetching.
-        self.log.info("Resuming flow...")
-        consumer.resume_flow()
-        app.flow_control.resume()
         assignment = consumer.assignment()
         if self.app.consumer_generation_id != generation_id:
             self.log.warning("Recovery rebalancing again")
@@ -324,6 +320,10 @@ class Recovery(Service):
         else:
             self.log.info("Resuming streams with empty assignment")
         self.completed.set()
+        # Resume partitions and start fetching.
+        self.log.info("Resuming flow...")
+        consumer.resume_flow()
+        app.flow_control.resume()
         # finally make sure the fetcher is running.
         await cast(_App, app)._fetcher.maybe_start()
         self.tables.on_actives_ready()


### PR DESCRIPTION
## Description

Fixes https://github.com/faust-streaming/faust/issues/216 

During a rebalance, faust implements multiple branches for recovery to resume processing such as in `Recovery.on_recovery_completed` and `Recovery._restart_recovery`  which roughly follow the pattern of:

  1. `self.log.info("Seek stream partitions to committed offsets.")`
  1. `consumer.perform_seek()`
  1. `self.log.dev("Resume stream partitions")`
  1. `consumer.resume_partitions(`
  1. `consumer.resume_flow()`
  1. `self.app.flow_control.resume()`

However, when the application doesn't use any tables, `_restart_recovery` calls `_resume_streams` which follows the pattern:

  1. `consumer.resume_flow()`
  1. `app.flow_control.resume()`
  1. `self.log.info("Seek stream partitions to committed offsets.")`
  1. `consumer.perform_seek()`
  1. `self.log.dev("Resume stream partitions")`
  1. `consumer.resume_partitions(`

In this case, `app.flow_control.resume()` is called before `consumer.perform_seek()`. This can cause some race conditions where the consumer starts fetching messages from where it left off before queues were cleared by `app.flow_control.suspend()`. Since `suspend` clears queues, if the consumer starts fetching again before seeking back to the last committed offset, a gap appears in the processing. 

This change brings the order of calls in `_resume_streams` in line with elsewhere in the class. 
