### PR TITLE
add default to external_topic_distribution

### DIFF
--- a/faust/assignor/client_assignment.py
+++ b/faust/assignor/client_assignment.py
@@ -149,7 +149,7 @@ class ClientMetadata(
     assignment: ClientAssignment
     url: str
     changelog_distribution: HostToPartitionMap
-    external_topic_distribution: HostToPartitionMap
+    external_topic_distribution: HostToPartitionMap = cast(HostToPartitionMap, {})
     topic_groups: Mapping[str, int] = cast(Mapping[str, int], None)
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
## Description

v.0.6.11 crashes when a node is started and existing nodes are already running (in my case with v.0.6.10) throwing the following error:

```
2021/11/18 00:31:10.688 INFO  [aiokafka.consumer.group_coordinator] (perform_group_join) Joined group 'xyz' (generation 1050) with member_id faust-0.6.11-81bf5542-3e54-4cdd-8197-5c53d04b4bd0
2021/11/18 00:31:10.784 INFO  [aiokafka.consumer.group_coordinator] (_send_sync_group_request) Successfully synced group xyz with generation 1050
2021/11/18 00:31:10.785 ERROR [aiokafka.consumer.group_coordinator] (_coordination_routine) Unexpected error in coordinator routine
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/aiokafka/consumer/group_coordinator.py", line 555, in _coordination_routine
    await self.__coordination_routine()
  File "/usr/local/lib/python3.7/site-packages/aiokafka/consumer/group_coordinator.py", line 599, in __coordination_routine
    subscription, assignment)
  File "/usr/local/lib/python3.7/site-packages/aiokafka/consumer/group_coordinator.py", line 695, in ensure_active_group
    success = await self._do_rejoin_group(subscription)
  File "/usr/local/lib/python3.7/site-packages/aiokafka/consumer/group_coordinator.py", line 896, in _do_rejoin_group
    protocol, member_assignment_bytes)
  File "/usr/local/lib/python3.7/site-packages/aiokafka/consumer/group_coordinator.py", line 455, in _on_join_complete
    assignor.on_assignment(assignment)
  File "/usr/local/lib/python3.7/site-packages/faust/assignor/partition_assignor.py", line 132, in on_assignment
    ClientMetadata, ClientMetadata.loads(self._decompress(assignment.user_data))
  File "/usr/local/lib/python3.7/site-packages/faust/models/base.py", line 249, in loads
    return cls.from_data(data)
  File "/usr/local/lib/python3.7/site-packages/faust/models/record.py", line 305, in from_data
    return (self_cls or cls)(**data, __strict__=False)
TypeError: __init__() missing 1 required positional argument: 'external_topic_distribution'
```


This behavior can result in deployment issues when a new version of an application (running v.0.6.11) gets deployed with a CI/CD pipeline that waits for successful deployment of the new version before destroying the old one.