### PR TITLE
Discard message after rebalance

### DIFF
--- a/faust/_cython/streams.pyx
+++ b/faust/_cython/streams.pyx
@@ -162,7 +162,8 @@ cdef class StreamIterator:
 
             if message.generation_id != self.app.consumer_generation_id:
                 self.app.log.dev(
-                    "Skipping message %r with generation_id %r because app generation_id is %r",
+                    "Skipping message %r with generation_id %r because "
+                    "app generation_id is %r",
                     message,
                     message.generation_id,
                     self.app.consumer_generation_id,

--- a/faust/_cython/streams.pyx
+++ b/faust/_cython/streams.pyx
@@ -161,6 +161,12 @@ cdef class StreamIterator:
             consumer = self.consumer
 
             if message.generation_id != self.app.consumer_generation_id:
+                self.app.log.dev(
+                    "Skipping message %r with generation_id %r because app generation_id is %r",
+                    message,
+                    message.generation_id,
+                    self.app.consumer_generation_id,
+                )
                 return None, self._skipped_value, stream_state
 
             if topic in self.acking_topics and not message.tracked:

--- a/faust/agents/agent.py
+++ b/faust/agents/agent.py
@@ -1184,6 +1184,7 @@ class AgentTestWrapper(Agent, AgentTestWrapperT):  # pragma: no cover
             checksum=b"",
             serialized_key_size=0,
             serialized_value_size=0,
+            generation_id=self.app.consumer_generation_id,
         )
 
     async def throw(self, exc: BaseException) -> None:

--- a/faust/channels.py
+++ b/faust/channels.py
@@ -288,6 +288,7 @@ class Channel(ChannelT[T]):
                 # [ask]
                 topic=None,
                 offset=None,
+                generation_id=self.app.consumer_generation_id,
             ),
         )
 

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -975,7 +975,8 @@ class Stream(StreamT[T_co], Service):
                         offset = message.offset
 
                         if message.generation_id != self.app.consumer_generation_id:
-                            continue
+                            value = skipped_value
+                            break
                         if topic in acking_topics and not message.tracked:
                             message.tracked = True
                             # This inlines Consumer.track_message(message)

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -977,7 +977,8 @@ class Stream(StreamT[T_co], Service):
                         if message.generation_id != self.app.consumer_generation_id:
                             value = skipped_value
                             self.log.dev(
-                                "Skipping message %r with generation_id %r because app generation_id is %r",
+                                "Skipping message %r with generation_id %r because "
+                                "app generation_id is %r",
                                 message,
                                 message.generation_id,
                                 self.app.consumer_generation_id,

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -976,6 +976,12 @@ class Stream(StreamT[T_co], Service):
 
                         if message.generation_id != self.app.consumer_generation_id:
                             value = skipped_value
+                            self.log.dev(
+                                "Skipping message %r with generation_id %r because app generation_id is %r",
+                                message,
+                                message.generation_id,
+                                self.app.consumer_generation_id,
+                            )
                             break
                         if topic in acking_topics and not message.tracked:
                             message.tracked = True

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -974,6 +974,8 @@ class Stream(StreamT[T_co], Service):
                         tp = message.tp
                         offset = message.offset
 
+                        if message.generation_id != self.app.consumer_generation_id:
+                            continue
                         if topic in acking_topics and not message.tracked:
                             message.tracked = True
                             # This inlines Consumer.track_message(message)

--- a/faust/tables/recovery.py
+++ b/faust/tables/recovery.py
@@ -304,10 +304,6 @@ class Recovery(Service):
         app = self.app
         consumer = app.consumer
         await app.on_rebalance_complete.send()
-        # Resume partitions and start fetching.
-        self.log.info("Resuming flow...")
-        consumer.resume_flow()
-        app.flow_control.resume()
         assignment = consumer.assignment()
         if self.app.consumer_generation_id != generation_id:
             self.log.warning("Recovery rebalancing again")
@@ -324,6 +320,10 @@ class Recovery(Service):
         else:
             self.log.info("Resuming streams with empty assignment")
         self.completed.set()
+        # Resume partitions and start fetching.
+        self.log.info("Resuming flow...")
+        consumer.resume_flow()
+        app.flow_control.resume()
         # finally make sure the fetcher is running.
         await cast(_App, app)._fetcher.maybe_start()
         self.tables.on_actives_ready()

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -267,6 +267,7 @@ class Consumer(ThreadDelegateConsumer):
             record.serialized_key_size,
             record.serialized_value_size,
             tp,
+            generation_id=self.app.consumer_generation_id,
         )
 
     async def on_stop(self) -> None:

--- a/faust/types/tuples.py
+++ b/faust/types/tuples.py
@@ -133,6 +133,7 @@ class Message:
         "tracked",
         "span",
         "__weakref__",
+        "generation_id",
     )
 
     use_tracking: bool = False
@@ -154,6 +155,7 @@ class Message:
         time_in: float = None,
         time_out: float = None,
         time_total: float = None,
+        generation_id: int = None,
     ) -> None:
         self.topic: str = topic
         self.partition: int = partition
@@ -182,6 +184,12 @@ class Message:
         #: Total processing time (in seconds), or None if the event is
         #: still processing.
         self.time_total: Optional[float] = time_total
+
+        # In some edge cases a message can slip through to the stream from before a
+        # rebalance occured if it gets stuck in the conductor or somewhere else. We
+        # track the generation_id when the message is fetched so we can discard if
+        # needed.
+        self.generation_id: Optional[int] = generation_id
 
     def ack(self, consumer: _ConsumerT, n: int = 1) -> bool:
         if not self.acked:

--- a/faust/types/tuples.py
+++ b/faust/types/tuples.py
@@ -69,6 +69,7 @@ class PendingMessage(NamedTuple):
     callback: Optional[MessageSentCallback]
     topic: Optional[str] = None
     offset: Optional[int] = None
+    generation_id: Optional[int] = None
 
 
 def _PendingMessage_to_Message(p: PendingMessage) -> "Message":
@@ -92,6 +93,7 @@ def _PendingMessage_to_Message(p: PendingMessage) -> "Message":
         value=p.value,
         checksum=None,
         tp=tp,
+        generation_id=p.generation_id,
     )
 
 

--- a/tests/functional/agents/helpers.py
+++ b/tests/functional/agents/helpers.py
@@ -191,6 +191,7 @@ class AgentCase(Service):
             value=value,
             checksum=checksum,
             tp=tp,
+            generation_id=self.app.consumer_generation_id,
         )
 
     def next_offset(self, tp: TP, *, offsets=CURRENT_OFFSETS) -> int:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,7 +15,8 @@ def message(
     timestamp=None,
     headers=None,
     offset=1,
-    checksum=None
+    checksum=None,
+    generation_id=0,
 ):
     return Message(
         key=key,
@@ -27,6 +28,7 @@ def message(
         timestamp_type=1 if timestamp else 0,
         headers=headers,
         checksum=checksum,
+        generation_id=generation_id,
     )
 
 


### PR DESCRIPTION
## Description

Fixes https://github.com/faust-streaming/faust/issues/221

This PR introduces two changes to avoid processing of events fetched before a rebalance:
- cancel the Conductor callback when `consumer.stop_flow` is called
- Add the `generation_id` to `Message` to support skipping events with a generation_id not matching the current generation_id. 
