### PR TITLE
Bump dependency - allow `click>=6.7,<=8.0`

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
 aiokafka>=0.7.1,<0.8.0
-click>=6.7,<8.0
+click>=6.7,<=8.0
 mode-streaming==0.1.0
 opentracing>=1.3.0,<=2.4.0
 terminaltables>=3.1,<4.0


### PR DESCRIPTION
## Description

Allows for click version `<=8.0`.

Tested locally with various versions of `click` and all tests passed.

See corresponding issue here: https://github.com/faust-streaming/faust/issues/230.