### PR TITLE
Cancel getmany if generation_id changes

### DIFF
--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -701,6 +701,7 @@ class Consumer(Service, ConsumerT):
         # has 1 partition, then t2 will end up being starved most of the time.
         #
         # We solve this by going round-robin through each topic.
+        generation_id = self.app.consumer_generation_id
         records, active_partitions = await self._wait_next_records(timeout)
         if records is None or self.should_stop:
             return
@@ -710,6 +711,14 @@ class Consumer(Service, ConsumerT):
         if self.flow_active:
             for tp, record in records_it:
                 if not self.flow_active:
+                    break
+                new_generation_id = self.app.consumer_generation_id
+                if new_generation_id != generation_id:
+                    self.log.dev(
+                        "Generation id changed from %r to %r. Cancelling getmany.",
+                        generation_id,
+                        new_generation_id,
+                    )
                     break
                 if (
                     active_partitions is None

--- a/faust/types/models.py
+++ b/faust/types/models.py
@@ -57,7 +57,6 @@ try:
     class _UsingKwargsInNew(_InitSubclassCheck, ident=909):
         ...
 
-
 except TypeError:
     abc_compatible_with_init_subclass = False
 else:

--- a/faust/utils/json.py
+++ b/faust/utils/json.py
@@ -179,7 +179,6 @@ if orjson is not None:  # pragma: no cover
         """Deserialize json string."""
         return json_loads(s)
 
-
 else:
 
     def dumps(


### PR DESCRIPTION
## Description

Found one more edge case where events from before a rebalance can leak through.  `Consumer.getmany` is designed to break out of the loop during a rebalance. However, if the asyncio loop never returns control to `getmany` during the rebalance, it will continue to yield events from before the rebalance, and `on_message` assigns the incorrect generation_id` Adding logic to check if the generation_id has changed for more robust handling. 