### PR TITLE
Record generation_id after fetch

### DIFF
--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -701,8 +701,8 @@ class Consumer(Service, ConsumerT):
         # has 1 partition, then t2 will end up being starved most of the time.
         #
         # We solve this by going round-robin through each topic.
-        generation_id = self.app.consumer_generation_id
         records, active_partitions = await self._wait_next_records(timeout)
+        generation_id = self.app.consumer_generation_id
         if records is None or self.should_stop:
             return
 


### PR DESCRIPTION
## Description
Limiting the comparison of generation_id to after the fetcher returns limits the scope of the check to a change of generation_id within getmany itself, leaving it up to the fetcher itself to avoid returning records after a rebalance. This avoids an issue where a rebalance happens during fetching, fetching waits for the rebalance to finishes to return, but then the fetch is discarded (incorrectly) by getmany. 