### PR TITLE
set active_tps in place

### DIFF
--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -769,7 +769,7 @@ class Consumer(Service, ConsumerT):
                 self.suspend_flow.wait(),
             )
             for coro, result in zip(wait_results.done, wait_results.results):
-                if coro == _getmany:
+                if coro is _getmany:
                     records = result
                     break
         else:

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -516,9 +516,10 @@ class Consumer(Service, ConsumerT):
         return tps
 
     def _set_active_tps(self, tps: Set[TP]) -> Set[TP]:
-        xtps = self._active_partitions = ensure_TPset(tps)  # copy
-        xtps.difference_update(self._paused_partitions)
-        return xtps
+        self._active_partitions.clear()
+        self._active_partitions.update(ensure_TPset(tps))
+        self._active_partitions.difference_update(self._paused_partitions)
+        return self._active_partitions
 
     def on_buffer_full(self, tp: TP) -> None:
         # do not remove the partition when in recovery

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -429,7 +429,7 @@ class Consumer(Service, ConsumerT):
     _commit_every: Optional[int]
     _n_acked: int = 0
 
-    _active_partitions: Optional[Set[TP]]
+    _active_partitions: Set[TP]
     _paused_partitions: Set[TP]
     _buffered_partitions: Set[TP]
 
@@ -495,7 +495,7 @@ class Consumer(Service, ConsumerT):
         return []
 
     def _reset_state(self) -> None:
-        self._active_partitions = None
+        self._active_partitions = set()
         self._paused_partitions = set()
         self._buffered_partitions = set()
         self.can_resume_flow.clear()

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -760,15 +760,16 @@ class Consumer(Service, ConsumerT):
             # Fetch records only if active partitions to avoid the risk of
             # fetching all partitions in the beginning when none of the
             # partitions is paused/resumed.
+            _getmany = self._getmany(
+                active_partitions=active_partitions,
+                timeout=timeout,
+            )
             wait_results = await self.wait_first(
-                self._getmany(
-                    active_partitions=active_partitions,
-                    timeout=timeout,
-                ),
+                _getmany,
                 self.suspend_flow.wait(),
             )
             for coro, result in zip(wait_results.done, wait_results.results):
-                if coro.__name__ == "_getmany":
+                if coro == _getmany:
                     records = result
                     break
         else:

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -516,6 +516,8 @@ class Consumer(Service, ConsumerT):
         return tps
 
     def _set_active_tps(self, tps: Set[TP]) -> Set[TP]:
+        if self._active_partitions is None:
+            self._active_partitions = set()
         self._active_partitions.clear()
         self._active_partitions.update(ensure_TPset(tps))
         self._active_partitions.difference_update(self._paused_partitions)


### PR DESCRIPTION
## Description

In some cases, we see that events are skipped by the consumer because `_active_partitions` becomes an empty set when partitions are revoked. Then, when new partitions are assigned, a new set is created instead of modifying the old set in place. This can break old references still pointing to the original object. This change modifies `_set_active_tps` to change the set in place. 