### PR TITLE
Take with timestamp

### DIFF
--- a/faust/streams.py
+++ b/faust/streams.py
@@ -392,8 +392,9 @@ class Stream(StreamT[T_co], Service):
             self.enable_acks = stream_enable_acks
             self._processors.remove(add_to_buffer)
 
-    async def take_with_timestamp(self, max_: int, within: Seconds,
-                                  timestamp_field_name: str) -> AsyncIterable[Sequence[T_co]]:
+    async def take_with_timestamp(
+        self, max_: int, within: Seconds, timestamp_field_name: str
+    ) -> AsyncIterable[Sequence[T_co]]:
         """Buffer n values at a time and yield a list of buffered values with the timestamp
            when the message was added to kafka.
 

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -395,7 +395,7 @@ class Stream(StreamT[T_co], Service):
     async def take_with_timestamp(self, max_: int, within: Seconds,
                                   timestamp_field_name: str) -> AsyncIterable[Sequence[T_co]]:
         """Buffer n values at a time and yield a list of buffered values with the timestamp
-           when the message was added to kafka including message offset.
+           when the message was added to kafka.
 
         Arguments:
             max_: Max number of messages to receive. When more than this
@@ -436,7 +436,6 @@ class Stream(StreamT[T_co], Service):
                         buffer_consuming = None
                 event = self.current_event
                 value[timestamp_field_name] = event.message.timestamp
-                value['kafka_offset'] = event.message.offset
                 buffer_add(value)
                 if event is None:
                     raise RuntimeError("Take buffer found current_event is None")

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -410,7 +410,7 @@ class Stream(StreamT[T_co], Service):
             timestamp_field_name: the name of the field containing kafka timestamp,
                 that is going to be added to the value
         """
-        buffer: List[EventT] = []
+        buffer: List[T_co] = []
         events: List[EventT] = []
         buffer_add = buffer.append
         event_add = events.append

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -436,7 +436,7 @@ class Stream(StreamT[T_co], Service):
                     finally:
                         buffer_consuming = None
                 event = self.current_event
-                if isinstance(value, dict):
+                if isinstance(value, dict) and timestamp_field_name:
                     value[timestamp_field_name] = event.message.timestamp
                 buffer_add(value)
                 if event is None:

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -421,7 +421,7 @@ class Stream(StreamT[T_co], Service):
 
         # We add this processor to populate the buffer, and the stream
         # is passively consumed in the background (enable_passive below).
-        async def add_to_buffer(event_to_add: EventT) -> EventT:
+        async def add_to_buffer(value: T) -> T:
             try:
                 # buffer_consuming is set when consuming buffer after timeout.
                 nonlocal buffer_consuming
@@ -430,10 +430,10 @@ class Stream(StreamT[T_co], Service):
                         await buffer_consuming
                     finally:
                         buffer_consuming = None
-                self.log.info(str(event_to_add.message.partition))
                 event = self.current_event
-                event_to_add['kafka_timestamp'] = event.message.timestamp
-                buffer_add(event_to_add)
+                self.log.info(str(event.message.timestamp))
+                value['kafka_timestamp'] = event.message.timestamp
+                buffer_add(value)
                 if event is None:
                     raise RuntimeError("Take buffer found current_event is None")
                 event_add(event)
@@ -449,7 +449,7 @@ class Stream(StreamT[T_co], Service):
             except Exception as exc:
                 self.log.exception("Error adding to take buffer: %r", exc)
                 await self.crash(exc)
-            return event_to_add
+            return value
 
         # Disable acks to ensure this method acks manually
         # events only after they are consumed by the user

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -395,7 +395,7 @@ class Stream(StreamT[T_co], Service):
     async def take_with_timestamp(self, max_: int, within: Seconds,
                                   timestamp_field_name: str) -> AsyncIterable[Sequence[T_co]]:
         """Buffer n values at a time and yield a list of buffered values with the timestamp
-           when the message was added to kafka.
+           when the message was added to kafka including message offset.
 
         Arguments:
             max_: Max number of messages to receive. When more than this
@@ -436,6 +436,7 @@ class Stream(StreamT[T_co], Service):
                         buffer_consuming = None
                 event = self.current_event
                 value[timestamp_field_name] = event.message.timestamp
+                value['kafka_offset'] = event.message.offset
                 buffer_add(value)
                 if event is None:
                     raise RuntimeError("Take buffer found current_event is None")

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -436,7 +436,8 @@ class Stream(StreamT[T_co], Service):
                     finally:
                         buffer_consuming = None
                 event = self.current_event
-                value[timestamp_field_name] = event.message.timestamp
+                if isinstance(value, dict):
+                    value[timestamp_field_name] = event.message.timestamp
                 buffer_add(value)
                 if event is None:
                     raise RuntimeError("Take buffer found current_event is None")

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -431,8 +431,9 @@ class Stream(StreamT[T_co], Service):
                     finally:
                         buffer_consuming = None
                 self.log.info(str(event_to_add.message.partition))
-                buffer_add(event_to_add)
                 event = self.current_event
+                event_to_add['kafka_timestamp'] = event.message.timestamp
+                buffer_add(event_to_add)
                 if event is None:
                     raise RuntimeError("Take buffer found current_event is None")
                 event_add(event)
@@ -483,7 +484,7 @@ class Stream(StreamT[T_co], Service):
         finally:
             # Restore last behaviour of "enable_acks"
             self.enable_acks = stream_enable_acks
-            # self._processors.remove(add_to_buffer)
+            self._processors.remove(add_to_buffer)
 
     def enumerate(self, start: int = 0) -> AsyncIterable[Tuple[int, T_co]]:
         """Enumerate values received on this stream.

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -392,6 +392,98 @@ class Stream(StreamT[T_co], Service):
             self.enable_acks = stream_enable_acks
             self._processors.remove(add_to_buffer)
 
+    async def full_take(self, max_: int, within: Seconds) -> AsyncIterable[Sequence[T_co]]:
+        """Buffer n events at a time and yield a list of buffered events.
+
+        Arguments:
+            max_: Max number of messages to receive. When more than this
+                number of messages are received within the specified number of
+                seconds then we flush the buffer immediately.
+            within: Timeout for when we give up waiting for another value,
+                and process the values we have.
+                Warning: If there's no timeout (i.e. `timeout=None`),
+                the agent is likely to stall and block buffered events for an
+                unreasonable length of time(!).
+        """
+        buffer: List[EventT] = []
+        events: List[EventT] = []
+        buffer_add = buffer.append
+        event_add = events.append
+        buffer_size = buffer.__len__
+        buffer_full = asyncio.Event(loop=self.loop)
+        buffer_consumed = asyncio.Event(loop=self.loop)
+        timeout = want_seconds(within) if within else None
+        stream_enable_acks: bool = self.enable_acks
+
+        buffer_consuming: Optional[asyncio.Future] = None
+
+        channel_it = aiter(self.channel)
+
+        # We add this processor to populate the buffer, and the stream
+        # is passively consumed in the background (enable_passive below).
+        async def add_to_buffer(event_to_add: EventT) -> EventT:
+            try:
+                # buffer_consuming is set when consuming buffer after timeout.
+                nonlocal buffer_consuming
+                if buffer_consuming is not None:
+                    try:
+                        await buffer_consuming
+                    finally:
+                        buffer_consuming = None
+                buffer_add(event_to_add)
+                event = self.current_event
+                if event is None:
+                    raise RuntimeError("Take buffer found current_event is None")
+                event_add(event)
+                if buffer_size() >= max_:
+                    # signal that the buffer is full and should be emptied.
+                    buffer_full.set()
+                    # strict wait for buffer to be consumed after buffer full.
+                    # If max is 1000, we are not allowed to return 1001 values.
+                    buffer_consumed.clear()
+                    await self.wait(buffer_consumed)
+            except CancelledError:  # pragma: no cover
+                raise
+            except Exception as exc:
+                self.log.exception("Error adding to take buffer: %r", exc)
+                await self.crash(exc)
+            return event_to_add
+
+        # Disable acks to ensure this method acks manually
+        # events only after they are consumed by the user
+        self.enable_acks = False
+
+        self.add_processor(add_to_buffer)
+        self._enable_passive(cast(ChannelT, channel_it))
+        try:
+            while not self.should_stop:
+                # wait until buffer full, or timeout
+                await self.wait_for_stopped(buffer_full, timeout=timeout)
+                if buffer:
+                    # make sure background thread does not add new items to
+                    # buffer while we read.
+                    buffer_consuming = self.loop.create_future()
+                    try:
+                        yield list(buffer)
+                    finally:
+                        buffer.clear()
+                        for event in events:
+                            await self.ack(event)
+                        events.clear()
+                        # allow writing to buffer again
+                        notify(buffer_consuming)
+                        buffer_full.clear()
+                        buffer_consumed.set()
+                else:  # pragma: no cover
+                    pass
+            else:  # pragma: no cover
+                pass
+
+        finally:
+            # Restore last behaviour of "enable_acks"
+            self.enable_acks = stream_enable_acks
+            self._processors.remove(add_to_buffer)
+
     def enumerate(self, start: int = 0) -> AsyncIterable[Tuple[int, T_co]]:
         """Enumerate values received on this stream.
 

--- a/tests/functional/test_streams.py
+++ b/tests/functional/test_streams.py
@@ -777,3 +777,94 @@ async def test_take__no_event_crashes(app, loop):
         assert isinstance(s._crash_reason, RuntimeError)
     print("RETURNING")
     assert s.enable_acks is True
+
+
+@pytest.mark.asyncio
+async def test_take_wit_timestamp(app):
+    async with new_stream(app) as s:
+        assert s.enable_acks is True
+        await s.channel.send(value={"id": 1})
+        event = None
+        async for value in s.take_with_timestamp(
+            1, within=1, timestamp_field_name="test_timestamp"
+        ):
+            assert "test_timestamp" in value[0].keys()
+            assert isinstance(value[0]["test_timestamp"], float)
+            assert s.enable_acks is False
+            event = mock_stream_event_ack(s)
+            break
+
+        assert event
+        # need one sleep on Python 3.6.0-3.6.6 + 3.7.0
+        # need two sleeps on Python 3.6.7 + 3.7.1 :-/
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        if not event.ack.called:
+            assert event.message.acked
+            assert not event.message.refcount
+        assert s.enable_acks is True
+
+
+@pytest.mark.asyncio
+async def test_take_wit_timestamp_wit_simple_value(app):
+    async with new_stream(app) as s:
+        assert s.enable_acks is True
+        await s.channel.send(value=1)
+        event = None
+        async for value in s.take_with_timestamp(
+            1, within=1, timestamp_field_name="test_timestamp"
+        ):
+            assert value == [1]
+            assert s.enable_acks is False
+            event = mock_stream_event_ack(s)
+            break
+
+        assert event
+        # need one sleep on Python 3.6.0-3.6.6 + 3.7.0
+        # need two sleeps on Python 3.6.7 + 3.7.1 :-/
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        if not event.ack.called:
+            assert event.message.acked
+            assert not event.message.refcount
+        assert s.enable_acks is True
+
+
+@pytest.mark.asyncio
+async def test_take_wit_timestamp__5(app, loop):
+    s = new_stream(app)
+    async with s:
+        assert s.enable_acks is True
+        for i in range(5):
+            await s.channel.send(value={"id": i})
+
+        event = None
+        buffer_processor = s.take_with_timestamp(
+            5, within=10.0, timestamp_field_name="test_timestamp"
+        )
+        async for batch in buffer_processor:
+            assert len(batch) == 5
+            assert all("test_timestamp" in _m.keys() for _m in batch)
+            assert s.enable_acks is False
+
+            event = mock_stream_event_ack(s)
+            break
+
+        try:
+            await buffer_processor.athrow(asyncio.CancelledError())
+        except asyncio.CancelledError:
+            pass
+
+        assert event
+        # need one sleep on Python 3.6.0-3.6.6 + 3.7.0
+        # need two sleeps on Python 3.6.7 + 3.7.1 :-/
+        await asyncio.sleep(0)  # needed for some reason
+        await asyncio.sleep(0)  # needed for some reason
+        await asyncio.sleep(0)  # needed for some reason
+
+    if not event.ack.called:
+        assert event.message.acked
+        assert not event.message.refcount
+    assert s.enable_acks is True


### PR DESCRIPTION
# Add take_with_timestamp

## Description

I'm currently using the take method of a stream in production. I have some cases where I would like to have not only the batch of values but a batch of values with the timestamp of when the message was inserted into kafka.

This PR adds a new method called take_with_timestamp, it works exactly like take, but it adds the Kafka timestamp to each returned value.

I tested in a local environment and seems working as expected, the real difference with take is this: 
```
value[timestamp_field_name] = event.message.timestamp
```
the name of the timestamp must be passed as an argument, to force to pass the name, some people might like kafka_timestamp, some event_timestamp, I preferred to leave it generic.

