### PR TITLE
Package bump - allow `click` < 8.1

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
 aiokafka>=0.7.1,<0.8.0
-click>=6.7,<=8.0
+click>=6.7,<8.1
 mode-streaming==0.1.0
 opentracing>=1.3.0,<=2.4.0
 terminaltables>=3.1,<4.0


### PR DESCRIPTION
This PR https://github.com/faust-streaming/faust/pull/231,  enabled `click` version <=8.0. What I really wanted (doh!) was < 8.1 (ie to be able to use the latest version of `click`, 8.0.3).

Tested locally with various versions of click in the 8.0.* range and all tests passed.

