### PR TITLE
fix condition to delete old table keys

### DIFF
--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -365,9 +365,7 @@ class Collection(Service, CollectionT):
         window = cast(WindowT, self.window)
         assert window
         for partition, timestamps in self._partition_timestamps.items():
-            while timestamps and window.stale(
-                timestamps[0], self._partition_latest_timestamp[partition]
-            ):
+            while timestamps and window.stale(timestamps[0], time.time()):
                 timestamp = heappop(timestamps)
                 keys_to_remove = self._partition_timestamp_keys.pop(
                     (partition, timestamp), None


### PR DESCRIPTION
## Description
When sending a single message,`on_window_close ` callback is not triggered. It is triggered only after sending a second message to the stream.
In _del_old_keys(), window.stale is always calculated based on `self._partition_latest_timestamp[partition]` which will always be the same as `timestamps[0]` if there is only one message in stream:
```
window.stale(timestamps[0], self._partition_latest_timestamp[partition])
```

## Related issue
Following the issue https://github.com/faust-streaming/faust/issues/250 

## Slack thread
Following the Slack discussion https://fauststream.slack.com/archives/C7FL9CB5E/p1641131986210500