### PR TITLE
resetting the fetcher if the app is not ready

### DIFF
--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -732,6 +732,8 @@ class Consumer(Service, ConsumerT):
                     self.app.monitor.track_tp_end_offset(tp, highwater_mark)
                     # convert timestamp to seconds from int milliseconds.
                     yield tp, to_message(tp, record)
+        else:
+            await self.perform_seek()
 
     async def _wait_next_records(
         self, timeout: float


### PR DESCRIPTION
## Description
This change resets the fetcher to the committed offset if the faust app is not ready to consume events
