### PR TITLE
Stop fetching when flow stops

### DIFF
--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -1681,6 +1681,9 @@ class App(AppT, Service):
                     T(self.flow_control.suspend)()
                     on_timeout.info("consumer.pause_partitions")
                     T(consumer.pause_partitions)(assignment)
+                    on_timeout.info("consumer.wait_for_stopped_flow")
+                    await T(consumer.wait_for_stopped_flow)()
+
                     # Every agent instance has an incoming buffer of messages
                     # (a asyncio.Queue) -- we clear those to make sure
                     # agents will not start processing them.

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -299,6 +299,7 @@ class Test_App:
             transactions=Mock(
                 on_partitions_revoked=AsyncMock(),
             ),
+            wait_for_stopped_flow=AsyncMock(),
         )
         app.tables = Mock()
         app.flow_control = Mock()


### PR DESCRIPTION
## Description
Changes
1. During recovery, resume the consumer after the app. When the app flow_control resumes it clears all queues, and resuming the consumer after the flow control makes sure that we don't write data to the app which is then discarded.
2. Added logic to the consumer to cancel the fetching coroutine during a rebalance. 
3. Moved the wait for flow to resume from `consumer._wait_next_records` to `consumer.getmany` to avoid a lock during rebalance
4. During a rebalance, the app waits for the consumer to cancel fetching before continuing, to avoid potential issues of discarding a fetch which occurs after assignment. 