### PR TITLE
Fix: Producer hangs on send pending check with thread producer enabled

### DIFF
--- a/faust/transport/producer.py
+++ b/faust/transport/producer.py
@@ -62,8 +62,11 @@ class ProducerBuffer(Service, ProducerBufferT):
                 (max_messages is None or flushed_messages < max_messages)
             ):
                 self.message_sent.clear()
-                await self.message_sent.wait()
-                flushed_messages += 1
+                try:
+                    await asyncio.wait_for(self.message_sent.wait(), timeout=0.1)
+                    flushed_messages += 1
+                except asyncio.TimeoutError:
+                    return flushed_messages
             else:
                 return flushed_messages
 


### PR DESCRIPTION
## Description

I discovered during implementation on top of faust that on high volume event consumptions that the whole process pipeline suddenly stopped doing anything. No further kafka messages were processed.

After checking the logic i realized that I enabled `PRODUCER_THREADED` and that the thread producer is not thread safe when waiting for new messages to come in.

This is fixed in this PR to avoid waiting forever for an event to be set in `flush_atmost`.
Instead it times out and returns the up until now identified amount of sent messages.

A unit test is added to verify the behavior of this change.