### PR TITLE
Rerouted HTTP requests retain the original request headers

### DIFF
--- a/faust/app/router.py
+++ b/faust/app/router.py
@@ -67,7 +67,9 @@ class Router(RouterT):
         if dest_ident == self._urlident(app.conf.canonical_url):
             raise SameNode()
         routed_url = request.url.with_host(host).with_port(int(port))
-        async with app.http_client.request(request.method, routed_url) as response:
+        async with app.http_client.request(
+            method=request.method, headers=request.headers, url=routed_url
+        ) as response:
             return web.text(
                 await response.text(),
                 content_type=response.content_type,

--- a/tests/unit/app/test_router.py
+++ b/tests/unit/app/test_router.py
@@ -116,8 +116,11 @@ class Test_Router:
         app.router.key_store = Mock()
         app.router.key_store.return_value = URL(f"{routed_url}:{routed_port}")
         await router.route_req("foo", "k", web, request)
+
         mock_http_client.request.assert_called_once_with(
-            request_method, request.url.with_host(routed_url).with_port(routed_port)
+            method=request_method,
+            headers=request.headers,
+            url=request.url.with_host(routed_url).with_port(routed_port),
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Description

When using the table_route decorator the headers of the original HTTP request issued to the initally targetted worker were lost.
Headers are now copied 1-to-1 before routing the request to the determined downstream worker
