### PR TITLE
Additional broker configs

### DIFF
--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -532,6 +532,8 @@ class AIOKafkaConsumerThread(ConsumerThread):
             rebalance_timeout_ms=int(rebalance_timeout * 1000.0),
             heartbeat_interval_ms=int(conf.broker_heartbeat_interval * 1000.0),
             isolation_level=isolation_level,
+            metadata_max_age_ms=int(conf.broker_metadata_max_age * 1000.0),
+            connections_max_idle_ms=int(conf.broker_connections_max_idle * 1000.0),
             # traced_from_parent_span=self.traced_from_parent_span,
             # start_rebalancing_span=self.start_rebalancing_span,
             # start_coordinator_span=self.start_coordinator_span,
@@ -1101,6 +1103,8 @@ class Producer(base.Producer):
             "partitioner": self.partitioner,
             "request_timeout_ms": int(self.request_timeout * 1000),
             "api_version": self._api_version,
+            "metadata_max_age_ms": self.metadata_max_age_ms,
+            "connections_max_idle_ms": self.connections_max_idle_ms,
         }
 
     def _settings_auth(self) -> Mapping[str, Any]:

--- a/faust/transport/producer.py
+++ b/faust/transport/producer.py
@@ -142,6 +142,8 @@ class Producer(Service, ProducerT):
         self.ssl_context = conf.ssl_context
         self.credentials = conf.broker_credentials
         self.partitioner = conf.producer_partitioner
+        self.metadata_max_age_ms = int(conf.broker_metadata_max_age * 1000.0)
+        self.connections_max_idle_ms = int(conf.broker_connections_max_idle * 1000.0)
         api_version = self._api_version = conf.producer_api_version
         assert api_version is not None
         super().__init__(loop=loop or self.transport.loop, **kwargs)

--- a/faust/types/settings/settings.py
+++ b/faust/types/settings/settings.py
@@ -1041,7 +1041,7 @@ class Settings(base.SettingsRegistry):
     @sections.Broker.setting(
         params.Seconds,
         env_name="BROKER_METADATA_MAX_AGE",
-        default=300.0
+        default=300.0,
     )
     def broker_metadata_max_age(self) -> float:
         """Broker metadata max age.
@@ -1054,7 +1054,7 @@ class Settings(base.SettingsRegistry):
     @sections.Broker.setting(
         params.Seconds,
         env_name="BROKER_CONNECTIONS_MAX_IDLE",
-        default=540.0
+        default=540.0,
     )
     def broker_connections_max_idle(self) -> float:
         """Broker connections max idle.

--- a/faust/types/settings/settings.py
+++ b/faust/types/settings/settings.py
@@ -106,6 +106,8 @@ class Settings(base.SettingsRegistry):
         broker_rebalance_timeout: Optional[Seconds] = None,
         broker_request_timeout: Optional[Seconds] = None,
         broker_session_timeout: Optional[Seconds] = None,
+        broker_metadata_max_age: Optional[Seconds] = None,
+        broker_connections_max_idle: Optional[Seconds] = None,
         ssl_context: ssl.SSLContext = None,
         # Consumer settings:
         consumer_api_version: Optional[str] = None,
@@ -1034,6 +1036,30 @@ class Settings(base.SettingsRegistry):
 
             The session timeout must not be greater than the
             :setting:`broker_request_timeout`.
+        """
+
+    @sections.Broker.setting(
+        params.Seconds,
+        env_name="BROKER_METADATA_MAX_AGE",
+        default=300.0
+    )
+    def broker_metadata_max_age(self) -> float:
+        """Broker metadata max age.
+
+        The period of time in seconds after which we force a refresh of metadata even
+        if we haven't seen any partition leadership changes to proactively discover any new
+        brokers or partitions.
+        """
+
+    @sections.Broker.setting(
+        params.Seconds,
+        env_name="BROKER_CONNECTIONS_MAX_IDLE",
+        default=540.0
+    )
+    def broker_connections_max_idle(self) -> float:
+        """Broker connections max idle.
+
+        Close idle connections after the number of seconds specified by this config.
         """
 
     @sections.Common.setting(


### PR DESCRIPTION
* connections_max_idle
* metadata_max_age

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

Need a way to specify aiokafka.consumer and .producer settings **connections_max_idle_ms** and **metadata_max_age_ms**