### PR TITLE
Add support for additional sentry tags and arguments

### DIFF
--- a/faust/contrib/sentry.py
+++ b/faust/contrib/sentry.py
@@ -129,13 +129,15 @@ def setup(
     dsn: Optional[str] = None,
     workers: int = 4,
     max_queue_size: int = 1000,
-    loglevel: Optional[int] = None
+    loglevel: Optional[int] = None,
+    **kwargs
 ) -> None:
     sentry_handler = handler_from_dsn(
         dsn=dsn,
         workers=workers,
         qsize=max_queue_size,
         loglevel=loglevel,
+        **kwargs
     )
     if sentry_handler is not None:
         if sentry_sdk is None or _sdk_aiohttp is None:

--- a/faust/contrib/sentry.py
+++ b/faust/contrib/sentry.py
@@ -133,11 +133,7 @@ def setup(
     **kwargs
 ) -> None:
     sentry_handler = handler_from_dsn(
-        dsn=dsn,
-        workers=workers,
-        qsize=max_queue_size,
-        loglevel=loglevel,
-        **kwargs
+        dsn=dsn, workers=workers, qsize=max_queue_size, loglevel=loglevel, **kwargs
     )
     if sentry_handler is not None:
         if sentry_sdk is None or _sdk_aiohttp is None:


### PR DESCRIPTION
## Description

A small change to the sentry handler to support additional tags and arguments.

Currently, you can only set up a generic sentry handler with no additional arguments and tags as described here: [sentry configuration](https://docs.sentry.io/clients/python/advanced/). This is a small change that exposes additional arguments such as environment, release, tags, site, etc...

Not sure why this was not supported in the first place, as it looks like this was the intention.

