### PR TITLE
Fix stream filter not acking messages 

### DIFF
--- a/faust/streams.py
+++ b/faust/streams.py
@@ -1118,11 +1118,10 @@ class Stream(StreamT[T_co], Service):
                     except Skip:
                         value = skipped_value
 
-                if value is skipped_value:
-                    continue
-                self.events_total += 1
                 try:
-                    yield value
+                    if value is not skipped_value:
+                        self.events_total += 1
+                        yield value
                 finally:
                     self.current_event = None
                     if do_ack and event is not None:


### PR DESCRIPTION

## Description

The problem was when using `filter` function, it didn't ack messages that should be filtered out
As a result when the service is restarted same messages were processed again.
example code to reproduce:

```
def get_key(event: Dict[str, Any]) -> str:
    return str(event["id"])

def is_relevant_event(event: Dict[str, Any]) -> bool:
   print("Filtering")
   return False

@app.agent(input_topic)
async def process(stream: StreamT[Dict[str, Any]]) -> None:
    async for event in stream.filter(is_relevant_event).group_by(get_key):
        print("OK")
```

In the above code the stream will always process the messages that was previously filtered out.

## Solution
The solution was to insert the `if` check inside the `try` block in order to execute the `finally` code which ack messages back.

