### PR TITLE
Improve monitor performance

### DIFF
--- a/faust/agents/manager.py
+++ b/faust/agents/manager.py
@@ -125,7 +125,7 @@ class AgentManager(Service, AgentManagerT, ManagedUserDict):
 
     def _collect_agents_for_update(self, tps: Set[TP]) -> Dict[AgentT, Set[TP]]:
         by_agent: Dict[AgentT, Set[TP]] = defaultdict(set)
-        for topic, tps in tp_set_to_map(tps).items():
+        for topic, tps_of_topic in tp_set_to_map(tps).items():
             for agent in self._by_topic[topic]:
-                by_agent[agent].update(tps)
+                by_agent[agent].update(tps_of_topic)
         return by_agent

--- a/tests/functional/test_app.py
+++ b/tests/functional/test_app.py
@@ -668,7 +668,7 @@ class Test_settings:
         web_transport="udp://",
         web_in_thread=True,
         web_cors_options={  # noqa: B006
-            "http://example.com": ResourceOptions(
+            "http://example.com": ResourceOptions(  # noqa: B008
                 allow_credentials=True,
                 expose_headers="*",
                 allow_headers="*",


### PR DESCRIPTION
## Description

Cache via a `WeakKeyDictionary` the str names of tasks and streams. This greatly reduces iterations as this code path takes 50% of the iteration loop on streams in the _py_aiter function in my use case.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

