### PR TITLE
Update documentation to reference faust-streaming

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 *Note*: Before submitting this pull request, please review our [contributing
-guidelines](https://faust.readthedocs.io/en/master/contributing.html).
+guidelines](https://fauststream.com/en/latest/contributing.html).
 
 ## Description
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -55,3 +55,4 @@ The award for doing this in any significant capacity for one year or longer, is 
 | Eran Kampf          | <ekampf@users.noreply.github.com>     |
 | Wjatscheslaw Kewlin | <Wjatscheslaw.Kewlin@d-fine.de>       |
 | Ramkumar M          | <ramchiyan1093@gmail.com>             |
+| Mark Lambert        | <mark.lambert@gmail.com>              |

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
 ## Documentation
 
-- `introduction`: http://faust.readthedocs.io/en/latest/introduction.html
-- `quickstart`: http://faust.readthedocs.io/en/latest/playbooks/quickstart.html
-- `User Guide`: http://faust.readthedocs.io/en/latest/userguide/index.html
+- `introduction`: https://fauststream.com/en/latest/introduction.html
+- `quickstart`: https://fauststream.com/en/latest/playbooks/quickstart.html
+- `User Guide`: https://fauststream.com/en/latest/userguide/index.html
 
 ## Why the fork
 
@@ -285,7 +285,7 @@ Aerospike can be enabled as the state store by specifying
 
 By default all tables backed by Aerospike use `use_partitioner=True` and generate changelog topic events similar
 to a state store backed by RocksDB.
-The following configuration options should be passed in as keys to the options parameter in [Table](https://faust.readthedocs.io/en/latest/reference/faust.tables.html)
+The following configuration options should be passed in as keys to the options parameter in [Table](https://fauststream.com/en/latest/reference/faust.tables.html)
 `namespace` : aerospike namespace
 
 `ttl`: TTL for all KV's in the table
@@ -355,7 +355,7 @@ you are not currently using a virtualenv.
 You can install the latest snapshot of Faust using the following `pip` command:
 
 ```sh
-pip install https://github.com/robinhood/faust/zipball/master#egg=faust
+pip install https://github.com/faust-streaming/faust/zipball/master#egg=faust
 ```
 
 ## FAQ
@@ -428,7 +428,7 @@ For discussions about the usage, development, and future of Faust, please join t
 ### Bug tracker
 
 If you have any suggestions, bug reports, or annoyances please report them
-to our issue tracker at https://github.com/robinhood/faust/issues/
+to our issue tracker at https://github.com/faust-streaming/faust/issues/
 
 ## License
 
@@ -436,7 +436,7 @@ This software is licensed under the `New BSD License`. See the `LICENSE` file in
 
 ### Contributing
 
-Development of `Faust` happens at [GitHub](https://github.com/robinhood/faust)
+Development of `Faust` happens at [GitHub](https://github.com/faust-streaming/faust)
 
 You're highly encouraged to participate in the development of `Faust`.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ globals().update(conf.build_config(
     project='Faust',
     version_dev='1.1',
     version_stable='1.0',
-    canonical_url='http://faust.readthedocs.io',
+    canonical_url='https://fauststream.com/en/latest',
     webdomain='',
     github_project='robinhood/faust',
     copyright='2017-2020',

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -158,7 +158,7 @@ Issue Trackers
 Bugs for a package in the Faust ecosystem should be reported to the relevant
 issue tracker.
 
-* :pypi:`Faust` - https://github.com/robinhood/faust/issues
+* :pypi:`Faust` - https://github.com/faust-streaming/faust/issues
 * :pypi:`Mode` - https://github.com/ask/mode/issues
 
 If you're unsure of the origin of the bug you can ask the
@@ -191,12 +191,12 @@ Branches
 
 Current active version branches:
 
-* dev (which git calls "master") (https://github.com/robinhood/faust/tree/master)
-* 1.0 (https://github.com/robinhood/faust/tree/1.0)
+* dev (which git calls "master") (https://github.com/faust-streaming/faust/tree/master)
+* 1.0 (https://github.com/faust-streaming/faust/tree/1.0)
 
 You can see the state of any branch by looking at the Changelog:
 
-    https://github.com/robinhood/faust/blob/master/Changelog.rst
+    https://github.com/faust-streaming/faust/blob/master/Changelog.rst
 
 If the branch is in active development the topmost version info should
 contain meta-data like:
@@ -317,7 +317,7 @@ to upstream changes:
 .. sourcecode:: console
 
     $ cd faust
-    $ git remote add upstream git://github.com/robinhood/faust.git
+    $ git remote add upstream git://github.com/faust-streaming/faust.git
     $ git fetch upstream
 
 If you need to pull in new changes from upstream you should
@@ -794,11 +794,11 @@ Packages
 ``Faust``
 ---------
 
-:git: https://github.com/robinhood/faust
+:git: https://github.com/faust-streaming/faust
 :CI: http://travis-ci.org/#!/robinhood/faust
 :Windows-CI: https://ci.appveyor.com/project/ask/faust
 :PyPI: :pypi:`faust`
-:docs: https://faust.readthedocs.io
+:docs: https://fauststream.com/en/latest/
 
 ``Mode``
 --------

--- a/docs/includes/installation.txt
+++ b/docs/includes/installation.txt
@@ -116,4 +116,4 @@ You can install the latest snapshot of Faust using the following
 
 .. sourcecode:: console
 
-    $ pip install https://github.com/robinhood/faust/zipball/master#egg=faust
+    $ pip install https://github.com/faust-streaming/faust/zipball/master#egg=faust

--- a/docs/includes/resources.txt
+++ b/docs/includes/resources.txt
@@ -23,7 +23,7 @@ Bug tracker
 -----------
 
 If you have any suggestions, bug reports, or annoyances please report them
-to our issue tracker at https://github.com/robinhood/faust/issues/
+to our issue tracker at https://github.com/faust-streaming/faust/issues/
 
 .. _license:
 

--- a/docs/includes/tags.txt
+++ b/docs/includes/tags.txt
@@ -1,6 +1,6 @@
 :Version: 1.10.4
-:Web: http://faust.readthedocs.io/
+:Web: https://fauststream.com/en/latest
 :Download: http://pypi.org/project/faust
-:Source: http://github.com/robinhood/faust
+:Source: http://github.com/faust-streaming/faust
 :Keywords: distributed, stream, async, processing, data, queue, state management
 

--- a/docs/templates/readme.txt
+++ b/docs/templates/readme.txt
@@ -33,7 +33,7 @@ Faust is...
 Contributing
 ============
 
-Development of `Faust` happens at GitHub: https://github.com/robinhood/faust
+Development of `Faust` happens at GitHub: https://github.com/faust-streaming/faust
 
 You're highly encouraged to participate in the development
 of `Faust`.
@@ -42,7 +42,7 @@ Be sure to also read the `Contributing to Faust`_ section in the
 documentation.
 
 .. _`Contributing to Faust`:
-    http://faust.readthedocs.io/en/latest/contributing.html
+    https://fauststream.com/en/latest/contributing.html
 
 .. include:: ../includes/code-of-conduct.txt
 

--- a/examples/django/proj/__init__.py
+++ b/examples/django/proj/__init__.py
@@ -14,7 +14,7 @@ from typing import NamedTuple
 __version__ = '0.9.3'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'opensource@robinhood.com'
-__homepage__ = 'http://faust.readthedocs.io'
+__homepage__ = 'https://fauststream.com/en/latest'
 __docformat__ = 'restructuredtext'
 
 # -eof meta-

--- a/extra/release/sphinx2rst_config.py
+++ b/extra/release/sphinx2rst_config.py
@@ -1,4 +1,4 @@
-REFBASE = 'http://faust.readthedocs.io/en/latest'
+REFBASE = 'https://fauststream.com/en/latest'
 REFS = {
     'slack-channel': 'getting-started/resources.html#slack-channel',
     'bundles': 'introduction/installation.html#bundles',

--- a/faust/cli/base.py
+++ b/faust/cli/base.py
@@ -442,7 +442,7 @@ def cli(*args: Any, **kwargs: Any) -> None:  # pragma: no cover
 
     Use --help for help, --version for version information.
 
-    https://faust.readthedocs.io
+    https://fauststream.com/en/latest
     """
     return _prepare_cli(*args, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,7 @@ def do_setup(**kwargs):
         project_urls={
             "Bug Reports": "https://github.com/faust-streaming/faust/issues",
             "Source": "https://github.com/faust-streaming/faust",
-            "Documentation": "https://faust.readthedocs.io/",
+            "Documentation": "https://fauststream.com/en/latest",
         },
         keywords=[
             "stream",


### PR DESCRIPTION
## Description

This PR updates the documentation to point to this faust-streaming repo and the fauststreaming.com site generated from this repo. It seems https://github.com/robinhood/faust is no longer maintained, and this repo is continuing the project. It seems appropriate to update the current docs so they can continue to evolve and help reduce confusion.  I could understand there may be some instances where the current maintainers want to keep things as-is during this point in the transition. I am happy to rework for any feedback.

I am not certain why but http://fauststream.com and https://fauststream.com redirect to the forked projects site https://faust.readthedocs.io. In instances where a URL was pointing to the root of the documentation page, I used the current default page https://fauststream.com/en/latest/ instead. I also updated HTTP to HTTPS where possible. All updated links are verified to be working.

Fixes #4 #265 #271
