### PR TITLE
Improve performance of recovery signal check

### DIFF
--- a/faust/tables/recovery.py
+++ b/faust/tables/recovery.py
@@ -754,7 +754,7 @@ class Recovery(Service):
             # the aiokafka consumer position and draining of the queue
             if timeout and self.app.in_transaction and timeout_count > 1:
                 await detect_aborted_tx()
-            if not self.need_recovery() and self.in_recovery:
+            if self.in_recovery and not self.need_recovery():
                 # apply anything stuck in the buffers
                 self.flush_buffers()
                 self._set_recovery_ended()


### PR DESCRIPTION
## Description

Switch the recovery signal check around to first check if we are in recovery mode and do not call the function if the first check is already returning False.

When running profiling on the faust system this function in a 120s profile does take 6.22 seconds. Most of it due to the function response being checked before the variable is checked in recovery.

Changing it around does first evaluate the in recovery method and only if this is true calls the need_recovery function.

This is easily checked by using something like:

```python
import sys
import time


class Test:
    def __init__(self) -> None:
        self.in_recovery = False

    def long_wait_time(self) -> bool:
        time.sleep(10)
        return False

    def run(self) -> None:
        if self.in_recovery and not self.long_wait_time():
            print("Hello")

    def run_reverse(self) -> None:
        if not self.long_wait_time() and self.in_recovery:
            print("Hello 2")


if __name__ == "__main__":
    if sys.argv[-1].endswith("reverse"):
        Test().run_reverse()
    else:
        Test().run()

```

And run

```bash
python -m cProfile test.py
python -m cProfile test.py --reverse
```