### PR TITLE
Minimize standby remaining total calls

### DIFF
--- a/faust/tables/recovery.py
+++ b/faust/tables/recovery.py
@@ -843,7 +843,10 @@ class Recovery(Service):
 
                 await _maybe_signal_recovery_end()
 
-                if not self.standby_remaining_total():
+                standby_ready = (
+                    self._standbys_span is None and self.tables.standbys_ready
+                )
+                if not standby_ready and not self.standby_remaining_total():
                     logger.debug("Completed standby partition fetch")
                     if self._standbys_span:
                         finish_span(self._standbys_span)


### PR DESCRIPTION
## Description

Reduce the calls in the recovery service agent checking if standby remaining totals is done by verifying on the tables if the standbys_ready is already set as this is the only thing which happens in the if statement and is computational cheap compared to iterating constantly over the standby_remaining_totals call.

Similar to https://github.com/faust-streaming/faust/pull/291 this should greatly reduce the time spent in the recovery
changelog service task which runs constantly in the background.