### PR TITLE
re-import orjson module for json serialization/deserialization

### DIFF
--- a/faust/utils/json.py
+++ b/faust/utils/json.py
@@ -28,7 +28,10 @@ __all__ = [
 if typing.TYPE_CHECKING:
     import orjson
 else:  # pragma: no cover
-    orjson = None  # noqa
+    try:
+        import orjson
+    except ImportError:
+        orjson = None  # noqa
 
 DEFAULT_TEXTUAL_TYPES: List[Type] = [Decimal, uuid.UUID, bytes]
 

--- a/faust/utils/json.py
+++ b/faust/utils/json.py
@@ -175,7 +175,6 @@ if orjson is not None:  # pragma: no cover
         return json_dumps(
             obj,
             default=on_default,
-            option=orjson.OPT_NAIVE_UTC,
         )
 
     def loads(s: str, json_loads: Callable = orjson.loads, **kwargs: Any) -> Any:
@@ -191,7 +190,12 @@ else:
         **kwargs: Any,
     ) -> str:
         """Serialize to json.  See :func:`json.dumps`."""
-        return json_dumps(obj, cls=cls, **dict(_JSON_DEFAULT_KWARGS, **kwargs))
+        return json_dumps(
+            obj,
+            cls=cls,
+            **dict(_JSON_DEFAULT_KWARGS, **kwargs),
+            separators=(",", ":"),
+        )
 
     def loads(s: str, json_loads: Callable = json.loads, **kwargs: Any) -> Any:
         """Deserialize json string.  See :func:`json.loads`."""

--- a/tests/functional/test_models.py
+++ b/tests/functional/test_models.py
@@ -106,7 +106,7 @@ def test_paramters_with_custom_init():
     assert p.y == 10
 
     payload = p.dumps(serializer="json")
-    assert payload == b'{"x": 30, "y": 10}'
+    assert payload == b'{"x":30,"y":10}'
 
     data = json.loads(payload)
     p2 = Point.from_data(data)
@@ -128,7 +128,7 @@ def test_parameters_with_custom_init_and_super():
     assert p.z == 40
 
     payload = p.dumps(serializer="json")
-    assert payload == b'{"x": 30, "y": 10}'
+    assert payload == b'{"x":30,"y":10}'
 
     data = json.loads(payload)
     p2 = Point.from_data(data)

--- a/tests/unit/stores/test_base.py
+++ b/tests/unit/stores/test_base.py
@@ -62,7 +62,7 @@ class Test_Store:
         )
 
     def test_encode_key(self, *, store):
-        assert store._encode_key({"foo": 1}) == b'{"foo": 1}'
+        assert store._encode_key({"foo": 1}) == b'{"foo":1}'
 
     def test_encode_key__cannot_be_None(self, *, store):
         store.key_serializer = "raw"
@@ -70,7 +70,7 @@ class Test_Store:
             store._encode_key(None)
 
     def test_encode_value(self, *, store):
-        assert store._encode_value({"foo": 1}) == b'{"foo": 1}'
+        assert store._encode_value({"foo": 1}) == b'{"foo":1}'
 
     def test_decode_key(self, *, store):
         assert store._decode_key(b'{"foo": 1}') == {"foo": 1}


### PR DESCRIPTION
## Description

`orjson` has been removed in the commit https://github.com/faust-streaming/faust/commit/0addeb9f5e0f447abc98a68e2f80ef1b31ef6370#diff-5ed855992d723de7bd9e127e572d89dd5fa3ad03816c3ba52de5fd7be53ba7eeL30

The point is to import back again as faust still have reference of `orjson` on its serialiazation/deserialization