### PR TITLE
support frozenset json serialization

### DIFF
--- a/faust/utils/json.py
+++ b/faust/utils/json.py
@@ -65,7 +65,7 @@ except ImportError:  # pragma: no cover
 DECIMAL_MAXLEN = 1000
 
 #: Types that we convert to lists.
-SEQUENCE_TYPES: TypeTuple[Iterable] = (set, deque)
+SEQUENCE_TYPES: TypeTuple[Iterable] = (set, frozenset, deque)
 
 DateTypeTuple = Tuple[Union[Type[datetime.date], Type[datetime.time]], ...]
 DatetimeTypeTuple = Tuple[

--- a/tests/unit/utils/test_json.py
+++ b/tests/unit/utils/test_json.py
@@ -69,6 +69,7 @@ def test_JSONEncoder():
     assert encoder.default(datetime.now(timezone.utc))
     assert encoder.default(Counter([("foo", 3), ("bar", 4)]))
     assert encoder.default(uuid4())
+    assert encoder.default(frozenset({1, 2, 3})) == [1, 2, 3]
     assert encoder.default(Flags.X) == "Xval"
     assert encoder.default(Flags.Y) == "Yval"
     assert encoder.default({1, 2, 3}) == [1, 2, 3]


### PR DESCRIPTION
## Description

Right now, when we try to serialize a frozenset on faust, we have an error similar as  ̀̀TypeError: Type is not JSON serializable: `frozenset`, however `set` is a totally valid type to serialize on faust. As both are built-in type, this PR add the support of `frozenset`.