### PR TITLE
Fix user guide create channel example to run

### DIFF
--- a/docs/userguide/application.rst
+++ b/docs/userguide/application.rst
@@ -244,7 +244,7 @@ Use :meth:`~@channel` to create an in-memory communication channel:
 
     @app.timer(1.0)
     async def populate():
-        await channel.send(MyModel(303))
+        await channel.send(value=MyModel(303))
 
 .. seealso::
 


### PR DESCRIPTION
## Description

Source code example of using a channel in `application.rst` errors when ran
Error: `TypeError: send() takes 1 positional argument but 2 were given`
Updated example to use a keyword argument