### PR TITLE
Add method to RocksDB for backing up partitions

### DIFF
--- a/faust/stores/aerospike.py
+++ b/faust/stores/aerospike.py
@@ -263,7 +263,9 @@ class AeroSpikeStore(base.SerializedStore):
                 )  # crash the app to prevent the offset from progressing
             raise ex
 
-    async def backup_partition(self, tp: Union[TP, int], flush: bool = True, purge: bool = False, keep: int = 1) -> None:
+    async def backup_partition(
+        self, tp: Union[TP, int], flush: bool = True, purge: bool = False, keep: int = 1
+    ) -> None:
         """Backup partition from this store.
 
         Not yet implemented for Aerospike.
@@ -271,7 +273,9 @@ class AeroSpikeStore(base.SerializedStore):
         """
         raise NotImplementedError("Not yet implemented for Aerospike.")
 
-    def restore_backup(self, tp: Union[TP, int], latest: bool = True, backup_id: int = 0) -> None:
+    def restore_backup(
+        self, tp: Union[TP, int], latest: bool = True, backup_id: int = 0
+    ) -> None:
         """Restore partition backup from this store.
 
         Not yet implemented for Aerospike.

--- a/faust/stores/aerospike.py
+++ b/faust/stores/aerospike.py
@@ -262,3 +262,11 @@ class AeroSpikeStore(base.SerializedStore):
                     ex
                 )  # crash the app to prevent the offset from progressing
             raise ex
+
+    async def backup_partition(self, partition: int, flush: bool = True, purge: bool = False, keep: int = 1) -> None:
+        """Backup partition from this store.
+
+        Not yet implemented for Aerospike.
+
+        """
+        raise NotImplementedError("Not yet implemented for Aerospike.")

--- a/faust/stores/aerospike.py
+++ b/faust/stores/aerospike.py
@@ -270,3 +270,11 @@ class AeroSpikeStore(base.SerializedStore):
 
         """
         raise NotImplementedError("Not yet implemented for Aerospike.")
+
+    def restore_backup(self, tp: Union[TP, int], latest: bool = True, backup_id: int = 0) -> None:
+        """Restore partition backup from this store.
+
+        Not yet implemented for Aerospike.
+
+        """
+        raise NotImplementedError("Not yet implemented for Aerospike.")

--- a/faust/stores/aerospike.py
+++ b/faust/stores/aerospike.py
@@ -263,7 +263,7 @@ class AeroSpikeStore(base.SerializedStore):
                 )  # crash the app to prevent the offset from progressing
             raise ex
 
-    async def backup_partition(self, partition: int, flush: bool = True, purge: bool = False, keep: int = 1) -> None:
+    async def backup_partition(self, tp: TP, flush: bool = True, purge: bool = False, keep: int = 1) -> None:
         """Backup partition from this store.
 
         Not yet implemented for Aerospike.

--- a/faust/stores/aerospike.py
+++ b/faust/stores/aerospike.py
@@ -263,7 +263,7 @@ class AeroSpikeStore(base.SerializedStore):
                 )  # crash the app to prevent the offset from progressing
             raise ex
 
-    async def backup_partition(self, tp: TP, flush: bool = True, purge: bool = False, keep: int = 1) -> None:
+    async def backup_partition(self, tp: Union[TP, int], flush: bool = True, purge: bool = False, keep: int = 1) -> None:
         """Backup partition from this store.
 
         Not yet implemented for Aerospike.

--- a/faust/stores/memory.py
+++ b/faust/stores/memory.py
@@ -90,3 +90,10 @@ class Store(base.Store, base.StoreT[KT, VT]):
 
         """
         ...
+
+    def restore_backup(self, tp: Union[TP, int], latest: bool = True, backup_id: int = 0) -> None:
+        """Restore partition backup from this store.
+
+        This does nothing when using the in-memory store.
+
+        """

--- a/faust/stores/memory.py
+++ b/faust/stores/memory.py
@@ -83,7 +83,7 @@ class Store(base.Store, base.StoreT[KT, VT]):
         """
         ...
 
-    async def backup_partition(self, partition: int, flush: bool = True, purge: bool = False, keep: int = 1) -> None:
+    async def backup_partition(self, tp: TP, flush: bool = True, purge: bool = False, keep: int = 1) -> None:
         """Backup partition from this store.
 
         This does nothing when using the in-memory store.

--- a/faust/stores/memory.py
+++ b/faust/stores/memory.py
@@ -83,7 +83,9 @@ class Store(base.Store, base.StoreT[KT, VT]):
         """
         ...
 
-    async def backup_partition(self, tp: Union[TP, int], flush: bool = True, purge: bool = False, keep: int = 1) -> None:
+    async def backup_partition(
+        self, tp: Union[TP, int], flush: bool = True, purge: bool = False, keep: int = 1
+    ) -> None:
         """Backup partition from this store.
 
         This does nothing when using the in-memory store.
@@ -91,7 +93,9 @@ class Store(base.Store, base.StoreT[KT, VT]):
         """
         ...
 
-    def restore_backup(self, tp: Union[TP, int], latest: bool = True, backup_id: int = 0) -> None:
+    def restore_backup(
+        self, tp: Union[TP, int], latest: bool = True, backup_id: int = 0
+    ) -> None:
         """Restore partition backup from this store.
 
         This does nothing when using the in-memory store.

--- a/faust/stores/memory.py
+++ b/faust/stores/memory.py
@@ -1,5 +1,5 @@
 """In-memory table storage."""
-from typing import Any, Callable, Iterable, MutableMapping, Optional, Set, Tuple
+from typing import Any, Callable, Iterable, MutableMapping, Optional, Set, Tuple, Union
 
 from faust.types import TP, EventT
 from faust.types.stores import KT, VT
@@ -83,7 +83,7 @@ class Store(base.Store, base.StoreT[KT, VT]):
         """
         ...
 
-    async def backup_partition(self, tp: TP, flush: bool = True, purge: bool = False, keep: int = 1) -> None:
+    async def backup_partition(self, tp: Union[TP, int], flush: bool = True, purge: bool = False, keep: int = 1) -> None:
         """Backup partition from this store.
 
         This does nothing when using the in-memory store.

--- a/faust/stores/memory.py
+++ b/faust/stores/memory.py
@@ -82,3 +82,11 @@ class Store(base.Store, base.StoreT[KT, VT]):
 
         """
         ...
+
+    async def backup_partition(self, partition: int, flush: bool = True, purge: bool = False, keep: int = 1) -> None:
+        """Backup partition from this store.
+
+        This does nothing when using the in-memory store.
+
+        """
+        ...

--- a/faust/stores/memory.py
+++ b/faust/stores/memory.py
@@ -97,3 +97,4 @@ class Store(base.Store, base.StoreT[KT, VT]):
         This does nothing when using the in-memory store.
 
         """
+        ...

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -194,15 +194,17 @@ class Store(base.SerializedStore):
     ) -> None:
         """Backup partition from this store.
 
-        This will be saved in a separate directory in the data directory called '{table-name}-backups'.
+        This will be saved in a separate directory in the data directory called
+        '{table-name}-backups'.
+
         Arguments:
             tp: Partition to backup
             flush: Flush the memset before backing up the state of the table.
             purge: Purge old backups in the process
             keep: How many backups to keep after purging
 
-        This is only supported in newer versions of python-rocksdb which can read the RocksDB
-        database using multi-process read access.
+        This is only supported in newer versions of python-rocksdb which can read
+        the RocksDB database using multi-process read access.
         See https://github.com/facebook/rocksdb/wiki/How-to-backup-RocksDB to know more.
         """
         partition = tp

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -188,11 +188,12 @@ class Store(base.SerializedStore):
         self.rebalance_ack = False
         self._backup_engine = rocksdb.BackupEngine(os.path.join(self.path, 'backups'))
 
-    async def backup_partition(self, partition: int, flush: bool = True, purge=False, keep=1):
+    async def backup_partition(self, partition: int, flush: bool = True, purge: bool = False, keep: int = 1) -> None:
         """Backup partition from this table.
 
         This will be saved in a separate directory in the data directory called '/backups'.
         Arguments:
+            partition: Index value of partition
             flush: Flush the memset before backing up the state of the table.
             purge: Purge old backups in the process
             keep: How many backups to keep after purging

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -189,7 +189,7 @@ class Store(base.SerializedStore):
         self._backup_engine = rocksdb.BackupEngine(os.path.join(self.path, 'backups'))
 
     async def backup_partition(self, partition: int, flush: bool = True, purge: bool = False, keep: int = 1) -> None:
-        """Backup partition from this table.
+        """Backup partition from this store.
 
         This will be saved in a separate directory in the data directory called '/backups'.
         Arguments:

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -194,7 +194,7 @@ class Store(base.SerializedStore):
     async def backup_partition(self, tp: Union[TP, int], flush: bool = True, purge: bool = False, keep: int = 1) -> None:
         """Backup partition from this store.
 
-        This will be saved in a separate directory in the data directory called '/backups'.
+        This will be saved in a separate directory in the data directory called '{table-name}-backups'.
         Arguments:
             tp: Partition to backup
             flush: Flush the memset before backing up the state of the table.

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -186,7 +186,7 @@ class Store(base.SerializedStore):
         self._key_index = LRUCache(limit=self.key_index_size)
         self.db_lock = asyncio.Lock()
         self.rebalance_ack = False
-        self._backup_path = os.path.join(self.path, 'backups')
+        self._backup_path = os.path.join(self.path, f"{str(self.basename)}-backups")
         if not os.path.isdir(self._backup_path):
             os.makedirs(self._backup_path, exist_ok=True)
         self._backup_engine = rocksdb.BackupEngine(self._backup_path)

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -187,6 +187,8 @@ class Store(base.SerializedStore):
         self.db_lock = asyncio.Lock()
         self.rebalance_ack = False
         self._backup_path = os.path.join(self.path, 'backups')
+        if not os.path.isdir(self._backup_path):
+            os.makedirs(self._backup_path, exist_ok=True)
         self._backup_engine = rocksdb.BackupEngine(self._backup_path)
 
     async def backup_partition(self, tp: Union[TP, int], flush: bool = True, purge: bool = False, keep: int = 1) -> None:

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -61,6 +61,7 @@ else:
     class Options:  # noqa
         """Dummy Options."""
 
+
 class PartitionDB(NamedTuple):
     """Tuple of ``(partition, rocksdb.DB)``."""
 
@@ -188,7 +189,9 @@ class Store(base.SerializedStore):
             os.makedirs(self._backup_path, exist_ok=True)
         self._backup_engine = rocksdb.BackupEngine(self._backup_path)
 
-    async def backup_partition(self, tp: Union[TP, int], flush: bool = True, purge: bool = False, keep: int = 1) -> None:
+    async def backup_partition(
+        self, tp: Union[TP, int], flush: bool = True, purge: bool = False, keep: int = 1
+    ) -> None:
         """Backup partition from this store.
 
         This will be saved in a separate directory in the data directory called '{table-name}-backups'.
@@ -209,14 +212,18 @@ class Store(base.SerializedStore):
             if flush:
                 db = await self._try_open_db_for_partition(partition)
             else:
-                db = self.rocksdb_options.open(self.partition_path(partition), read_only=True)
+                db = self.rocksdb_options.open(
+                    self.partition_path(partition), read_only=True
+                )
             self._backup_engine.create_backup(db, flush_before_backup=flush)
             if purge:
                 self._backup_engine.purge_old_backups(keep)
         except:
             self.log.info(f"Unable to backup partition {partition}.")
 
-    def restore_backup(self, tp: Union[TP, int], latest: bool = True, backup_id: int = 0) -> None:
+    def restore_backup(
+        self, tp: Union[TP, int], latest: bool = True, backup_id: int = 0
+    ) -> None:
         """Restore partition backup from this store.
 
         Arguments:
@@ -229,9 +236,13 @@ class Store(base.SerializedStore):
         if isinstance(tp, TP):
             partition = tp.partition
         if latest:
-            self._backup_engine.restore_latest_backup(str(self.partition_path(partition)), self._backup_path)
+            self._backup_engine.restore_latest_backup(
+                str(self.partition_path(partition)), self._backup_path
+            )
         else:
-            self._backup_engine.restore_backup(backup_id, str(self.partition_path(partition)), self._backup_path)
+            self._backup_engine.restore_backup(
+                backup_id, str(self.partition_path(partition)), self._backup_path
+            )
 
     def persisted_offset(self, tp: TP) -> Optional[int]:
         """Return the last persisted offset.

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -188,12 +188,12 @@ class Store(base.SerializedStore):
         self.rebalance_ack = False
         self._backup_engine = rocksdb.BackupEngine(os.path.join(self.path, 'backups'))
 
-    async def backup_partition(self, tp: TP, flush: bool = True, purge: bool = False, keep: int = 1) -> None:
+    async def backup_partition(self, tp: Union[TP, int], flush: bool = True, purge: bool = False, keep: int = 1) -> None:
         """Backup partition from this store.
 
         This will be saved in a separate directory in the data directory called '/backups'.
         Arguments:
-            partition: Index value of partition
+            tp: Partition to backup
             flush: Flush the memset before backing up the state of the table.
             purge: Purge old backups in the process
             keep: How many backups to keep after purging
@@ -202,11 +202,14 @@ class Store(base.SerializedStore):
         database using multi-process read access.
         See https://github.com/facebook/rocksdb/wiki/How-to-backup-RocksDB to know more.
         """
+        partition = tp
+        if isinstance(tp, TP):
+            partition = tp.partition
         try:
             if flush:
-                db = await self._try_open_db_for_partition(tp.partition)
+                db = await self._try_open_db_for_partition(partition)
             else:
-                db = self.rocksdb_options.open(self.partition_path(tp.partition), read_only=True)
+                db = self.rocksdb_options.open(self.partition_path(partition), read_only=True)
             self._backup_engine.create_backup(db, flush_before_backup=flush)
             if purge:
                 self._backup_engine.purge_old_backups(keep)

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -188,7 +188,7 @@ class Store(base.SerializedStore):
         self.rebalance_ack = False
         self._backup_engine = rocksdb.BackupEngine(os.path.join(self.path, 'backups'))
 
-    async def backup_partition(self, partition: int, flush: bool = True, purge: bool = False, keep: int = 1) -> None:
+    async def backup_partition(self, tp: TP, flush: bool = True, purge: bool = False, keep: int = 1) -> None:
         """Backup partition from this store.
 
         This will be saved in a separate directory in the data directory called '/backups'.
@@ -204,14 +204,14 @@ class Store(base.SerializedStore):
         """
         try:
             if flush:
-                db = await self._try_open_db_for_partition(partition)
+                db = await self._try_open_db_for_partition(tp.partition)
             else:
-                db = self.rocksdb_options.open(self.partition_path(partition), read_only=True)
+                db = self.rocksdb_options.open(self.partition_path(tp.partition), read_only=True)
             self._backup_engine.create_backup(db, flush_before_backup=flush)
             if purge:
                 self._backup_engine.purge_old_backups(keep)
         except:
-            self.log.info(f"Unable to backup partition {partition}.")
+            self.log.info(f"Unable to backup partition {tp.partition}.")
 
     def persisted_offset(self, tp: TP) -> Optional[int]:
         """Return the last persisted offset.

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -220,7 +220,6 @@ class Store(base.SerializedStore):
     def restore_backup(self, tp: Union[TP, int], latest: bool = True, backup_id: int = 0) -> None:
         """Restore partition backup from this store.
 
-        Not yet implemented for Aerospike.
         Arguments:
             tp: Partition to restore
             latest: Restore the latest backup, set as False to restore a specific ID

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -214,7 +214,7 @@ class Store(base.SerializedStore):
             if purge:
                 self._backup_engine.purge_old_backups(keep)
         except:
-            self.log.info(f"Unable to backup partition {tp.partition}.")
+            self.log.info(f"Unable to backup partition {partition}.")
 
     def persisted_offset(self, tp: TP) -> Optional[int]:
         """Return the last persisted offset.

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -62,7 +62,7 @@ else:
         """Dummy Options."""
 
     class BackupEngine:  # noqa
-        """Dummy Options."""
+        """Dummy BackupEngine."""
 
 class PartitionDB(NamedTuple):
     """Tuple of ``(partition, rocksdb.DB)``."""
@@ -202,7 +202,10 @@ class Store(base.SerializedStore):
         See https://github.com/facebook/rocksdb/wiki/How-to-backup-RocksDB to know more.
         """
         try:
-            db = await self._try_open_db_for_partition(partition)
+            if flush:
+                db = await self._try_open_db_for_partition(partition)
+            else:
+                db = self.rocksdb_options.open(self.partition_path(partition), read_only=True)
             self._backup_engine.create_backup(db, flush_before_backup=flush)
             if purge:
                 self._backup_engine.purge_old_backups(keep)

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -232,9 +232,9 @@ class Store(base.SerializedStore):
         if isinstance(tp, TP):
             partition = tp.partition
         if latest:
-            self._backup_engine.restore_latest_backup(self.partition_path(partition), self._backup_path)
+            self._backup_engine.restore_latest_backup(str(self.partition_path(partition)), self._backup_path)
         else:
-            self._backup_engine.restore_backup(backup_id, self.partition_path(partition), self._backup_path)
+            self._backup_engine.restore_backup(backup_id, str(self.partition_path(partition)), self._backup_path)
 
     def persisted_offset(self, tp: TP) -> Optional[int]:
         """Return the last persisted offset.

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -52,7 +52,7 @@ except ImportError:  # pragma: no cover
     rocksdb = None  # noqa
 
 if typing.TYPE_CHECKING:  # pragma: no cover
-    from rocksdb import DB, Options, BackupEngine
+    from rocksdb import DB, Options
 else:
 
     class DB:  # noqa
@@ -60,9 +60,6 @@ else:
 
     class Options:  # noqa
         """Dummy Options."""
-
-    class BackupEngine:  # noqa
-        """Dummy BackupEngine."""
 
 class PartitionDB(NamedTuple):
     """Tuple of ``(partition, rocksdb.DB)``."""

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -197,7 +197,7 @@ class Store(base.SerializedStore):
                 f'Unable to make directory for path "{self._backup_path}",'
                 f"disabling backups."
             )
-        except (OSError, IOError):
+        except OSError:
             self.log.warning(
                 f'Unable to create files in "{self._backup_path}",' f"disabling backups"
             )

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -220,7 +220,7 @@ class Store(base.SerializedStore):
             self._backup_engine.create_backup(db, flush_before_backup=flush)
             if purge:
                 self._backup_engine.purge_old_backups(keep)
-        except:
+        except Exception:
             self.log.info(f"Unable to backup partition {partition}.")
 
     def restore_backup(

--- a/faust/tables/objects.py
+++ b/faust/tables/objects.py
@@ -183,3 +183,16 @@ class ChangeloggedObjectManager(Store):
 
         for tp, offset in tp_offsets.items():
             self.set_persisted_offset(tp, offset)
+
+    async def backup_partition(
+        self, tp, flush: bool = True, purge: bool = False, keep: int = 1
+    ) -> None:
+        raise NotImplementedError
+
+    def restore_backup(
+        self,
+        tp,
+        latest: bool = True,
+        backup_id: int = 0,
+    ) -> None:
+        raise NotImplementedError

--- a/faust/types/stores.py
+++ b/faust/types/stores.py
@@ -101,3 +101,13 @@ class StoreT(ServiceT, FastUserDict[KT, VT]):
         self, active_tps: Set[TP], standby_tps: Set[TP]
     ) -> None:
         ...
+
+    @abc.abstractmethod
+    async def backup_partition(
+        self,
+        partition: int,
+        flush: bool = True,
+        purge: bool = False,
+        keep: int = 1
+    ) -> None:
+        ...

--- a/faust/types/stores.py
+++ b/faust/types/stores.py
@@ -105,7 +105,7 @@ class StoreT(ServiceT, FastUserDict[KT, VT]):
     @abc.abstractmethod
     async def backup_partition(
         self,
-        partition: int,
+        tp: Set[TP],
         flush: bool = True,
         purge: bool = False,
         keep: int = 1

--- a/faust/types/stores.py
+++ b/faust/types/stores.py
@@ -104,11 +104,7 @@ class StoreT(ServiceT, FastUserDict[KT, VT]):
 
     @abc.abstractmethod
     async def backup_partition(
-        self,
-        tp: Union[TP, int],
-        flush: bool = True,
-        purge: bool = False,
-        keep: int = 1
+        self, tp: Union[TP, int], flush: bool = True, purge: bool = False, keep: int = 1
     ) -> None:
         ...
 

--- a/faust/types/stores.py
+++ b/faust/types/stores.py
@@ -111,3 +111,12 @@ class StoreT(ServiceT, FastUserDict[KT, VT]):
         keep: int = 1
     ) -> None:
         ...
+
+    @abc.abstractmethod
+    def restore_backup(
+        self,
+        tp: Union[TP, int],
+        latest: bool = True,
+        backup_id: int = 0,
+    ) -> None:
+        ...

--- a/faust/types/stores.py
+++ b/faust/types/stores.py
@@ -105,7 +105,7 @@ class StoreT(ServiceT, FastUserDict[KT, VT]):
     @abc.abstractmethod
     async def backup_partition(
         self,
-        tp: Set[TP],
+        tp: Union[TP, int],
         flush: bool = True,
         purge: bool = False,
         keep: int = 1

--- a/tests/unit/stores/test_base.py
+++ b/tests/unit/stores/test_base.py
@@ -29,6 +29,19 @@ class MyStore(Store):
     def reset_state(self):
         ...
 
+    async def backup_partition(
+        self, tp, flush: bool = True, purge: bool = False, keep: int = 1
+    ) -> None:
+        ...
+
+    def restore_backup(
+        self,
+        tp,
+        latest: bool = True,
+        backup_id: int = 0,
+    ) -> None:
+        ...
+
 
 class Test_Store:
     @pytest.fixture

--- a/tests/unit/stores/test_base.py
+++ b/tests/unit/stores/test_base.py
@@ -133,6 +133,19 @@ class MySerializedStore(SerializedStore):
     def reset_state(self):
         ...
 
+    async def backup_partition(
+        self, tp, flush: bool = True, purge: bool = False, keep: int = 1
+    ) -> None:
+        ...
+
+    def restore_backup(
+        self,
+        tp,
+        latest: bool = True,
+        backup_id: int = 0,
+    ) -> None:
+        ...
+
 
 class Test_SerializedStore:
     @pytest.fixture


### PR DESCRIPTION
I have a specific use-case where I need to actively backup a RocksDB store. I've had success using `rocksdb.BackupEngine` with `faust` but it'd be much more usable if the code was integrated into `faust`.

I should note I've only had success with this using `librocksdb-dev==6.11.4-3` on Ubuntu 22.04 and the python-rocksdb bindings from https://github.com/NightTsarina/python-rocksdb.

If you have interest in this, let me know because I really need this feature.