### PR TITLE
Faust commits the wrong offset in case of a gap in acks #312

### DIFF
--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -1104,7 +1104,7 @@ class Consumer(Service, ConsumerT):
             #    34 35 36 37
             #  ^-- gap
             # self._committed_offset[tp] is 31
-            # the return value will be: 31
+            # the return value will be None (the same as 31)
             if self._committed_offset[tp]:
                 if min(acked) - self._committed_offset[tp] > 0:
                     return None

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -1107,7 +1107,7 @@ class Consumer(Service, ConsumerT):
             # the return value will be: 31
             if self._committed_offset[tp]:
                 if min(acked) - self._committed_offset[tp] > 0:
-                    return self._committed_offset[tp]
+                    return None
 
             # Note: acked is always kept sorted.
             # find first list of consecutive numbers

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -1097,6 +1097,18 @@ class Consumer(Service, ConsumerT):
                 acked.extend(gaps)
                 gap_for_tp[:gap_index] = []
             acked.sort()
+
+            # We iterate over it until we handle gap in the head of acked queue
+            # then return the previous committed offset.
+            # For example if acked[tp] is:
+            #    34 35 36 37
+            #  ^-- gap
+            # self._committed_offset[tp] is 31
+            # the return value will be: 31
+            if self._committed_offset[tp]:
+                if min(acked) - self._committed_offset[tp] > 0:
+                    return self._committed_offset[tp]
+
             # Note: acked is always kept sorted.
             # find first list of consecutive numbers
             batch = next(consecutive_numbers(acked))

--- a/scripts/tests
+++ b/scripts/tests
@@ -10,8 +10,8 @@ set -ex
 if [ -z $GITHUB_ACTIONS ]; then
     scripts/check
 fi
-${PREFIX}pytest tests/unit/transport/test_consumer.py $@
-# ${PREFIX}pytest tests/unit tests/functional tests/integration tests/meticulous/ tests/regression $@
+
+${PREFIX}pytest tests/unit tests/functional tests/integration tests/meticulous/ tests/regression $@
 ${PREFIX}bandit -b extra/bandit/baseline.json -c extra/bandit/config.yaml -r faust
 
 if [ -z $GITHUB_ACTIONS ]; then

--- a/scripts/tests
+++ b/scripts/tests
@@ -10,8 +10,8 @@ set -ex
 if [ -z $GITHUB_ACTIONS ]; then
     scripts/check
 fi
-
-${PREFIX}pytest tests/unit tests/functional tests/integration tests/meticulous/ tests/regression $@
+${PREFIX}pytest tests/unit/transport/test_consumer.py $@
+# ${PREFIX}pytest tests/unit tests/functional tests/integration tests/meticulous/ tests/regression $@
 ${PREFIX}bandit -b extra/bandit/baseline.json -c extra/bandit/config.yaml -r faust
 
 if [ -z $GITHUB_ACTIONS ]; then

--- a/tests/unit/transport/test_consumer.py
+++ b/tests/unit/transport/test_consumer.py
@@ -1080,6 +1080,8 @@ class TestConsumer:
             (TP1, [1, 2, 3, 4, 6, 7, 8, 10], [5], 9),
             (TP1, [1, 3, 4, 6, 7, 8, 10], [2, 5, 9], 11),
             (TP1, [3, 4], [], None),
+            (TP1, [3, 4], [2], None),
+            (TP1, [3, 4], [1, 2], 5),
         ],
     )
     def test_new_offset_with_gaps(self, tp, acked, gaps, expected_offset, *, consumer):

--- a/tests/unit/transport/test_consumer.py
+++ b/tests/unit/transport/test_consumer.py
@@ -1079,9 +1079,11 @@ class TestConsumer:
             (TP1, [1, 2, 3, 4, 5, 6, 7, 8, 10], [9], 11),
             (TP1, [1, 2, 3, 4, 6, 7, 8, 10], [5], 9),
             (TP1, [1, 3, 4, 6, 7, 8, 10], [2, 5, 9], 11),
+            (TP1, [3, 4], [], 1),
         ],
     )
     def test_new_offset_with_gaps(self, tp, acked, gaps, expected_offset, *, consumer):
+        consumer._committed_offset[tp] = 1
         consumer._acked[tp] = acked
         consumer._gap[tp] = gaps
         assert consumer._new_offset(tp) == expected_offset

--- a/tests/unit/transport/test_consumer.py
+++ b/tests/unit/transport/test_consumer.py
@@ -1079,7 +1079,7 @@ class TestConsumer:
             (TP1, [1, 2, 3, 4, 5, 6, 7, 8, 10], [9], 11),
             (TP1, [1, 2, 3, 4, 6, 7, 8, 10], [5], 9),
             (TP1, [1, 3, 4, 6, 7, 8, 10], [2, 5, 9], 11),
-            (TP1, [3, 4], [], 1),
+            (TP1, [3, 4], [], None),
         ],
     )
     def test_new_offset_with_gaps(self, tp, acked, gaps, expected_offset, *, consumer):


### PR DESCRIPTION
fix new_offset function edge case #312 

## Description

Add changes to handle gap in the head of acked queue:
- We iterate over it until we handle gap in the head of acked queue, then return the previous committed offset.
            # For example if acked[tp] is:
            #    34 35 36 37
            #  ^-- gap
            # self._committed_offset[tp] is 31
            # the return value will be: 31

