### PR TITLE
Fix flake warning with bound loop var

### DIFF
--- a/tests/bench/base.py
+++ b/tests/bench/base.py
@@ -94,8 +94,8 @@ class Benchmark:
                 time_start = monotonic()
                 time_1st = monotonic()
 
-                def on_published(meta):
-                    print(f"1ST OK: {meta} AFTER {monotonic() - time_1st}s")
+                def on_published(meta, time_start=time_start):
+                    print(f"1ST OK: {meta} AFTER {time_start - time_1st}s")
 
                 callback = on_published
             await topic.send(key=key, value=value, callback=callback)

--- a/tests/bench/base.py
+++ b/tests/bench/base.py
@@ -94,8 +94,8 @@ class Benchmark:
                 time_start = monotonic()
                 time_1st = monotonic()
 
-                def on_published(meta, time_start=time_start):
-                    print(f"1ST OK: {meta} AFTER {time_start - time_1st}s")
+                def on_published(meta, time_1st=time_1st):
+                    print(f"1ST OK: {meta} AFTER {monotonic() - time_1st}s")
 
                 callback = on_published
             await topic.send(key=key, value=value, callback=callback)


### PR DESCRIPTION
Many PRs were getting this issue:
```

Run scripts/check
+ isort --check --diff --project=faust faust tests setup.py
+ black --check --diff faust tests setup.py
All done! ✨ 🍰 ✨
342 files would be left unchanged.
+ flake8 faust tests setup.py
tests/bench/base.py:98:65: B023 Function definition does not bind loop variable 'time_1st'.
```

The goal of this PR is to fix the error.
