### PR TITLE
Allow rocksdb to accept read_only option in order to share tables among workers

### DIFF
--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -138,7 +138,10 @@ class RocksDBOptions:
 
 
 class Store(base.SerializedStore):
-    """RocksDB table storage."""
+    """RocksDB table storage.
+    Pass 'options={'read_only': True}' as an option into a Table class
+    to allow a RocksDB store be used by multiple apps.
+    """
 
     offset_key = b"__faust\0offset__"
 

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -178,10 +178,7 @@ class Store(base.SerializedStore):
         if not self.url.path:
             self.url /= self.table_name
         self.options = options or {}
-        self.read_only = read_only
-        if "read_only" in self.options:
-            self.read_only = self.options.get("read_only")
-            del self.options["read_only"]
+        self.read_only = self.options.pop("read_only", read_only)
         self.rocksdb_options = RocksDBOptions(**self.options)
         if key_index_size is None:
             key_index_size = app.conf.table_key_index_size

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -369,8 +369,9 @@ class Store(base.SerializedStore):
             return db
 
     def _open_for_partition(self, partition: int) -> DB:
+        path = self.partition_path(partition)
         return self.rocksdb_options.open(
-            self.partition_path(partition), read_only=self.read_only
+            path, read_only=self.read_only if os.path.isfile(path) else False
         )
 
     def _get(self, key: bytes) -> Optional[bytes]:

--- a/tests/unit/stores/test_rocksdb.py
+++ b/tests/unit/stores/test_rocksdb.py
@@ -236,7 +236,7 @@ class Test_Store:
     def test_open_for_partition(self, *, store):
         open = store.rocksdb_options.open = Mock(name="options.open")
         assert store._open_for_partition(1) is open.return_value
-        open.assert_called_once_with(store.partition_path(1))
+        open.assert_called_once_with(store.partition_path(1), read_only=False)
 
     def test__get__missing(self, *, store):
         store._get_bucket_for_key = Mock(name="get_bucket_for_key")


### PR DESCRIPTION
Closes #330, I've had success by running multiple Faust apps with the same data directory for RocksDB
```
app = faust.App("reuse-this-app-name")
app.GlobalTable('generic-table-name', options={'read_only': True})
```

I'd like to write some test cases/examples before merging this in order to understand how this works better. If this functionality is not intended, feel free to close this immediately.