### PR TITLE
Correct pypi link, tar filename and path

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,13 +334,13 @@ The following configuration options should be passed in as keys to the options p
 
 ## Downloading and installing from source
 
-Download the latest version of Faust from http://pypi.org/project/faust
+Download the latest version of Faust from https://pypi.org/project/faust-streaming/
 
 You can install it by doing:
 
 ```sh
-$ tar xvfz faust-0.0.0.tar.gz
-$ cd faust-0.0.0
+$ tar xvfz faust-streaming-0.0.0.tar.gz
+$ cd faust-streaming-0.0.0
 $ python setup.py build
 # python setup.py install
 ```


### PR DESCRIPTION
## Description

Thanks for creating the faust-streaming fork.

We have been using faust for a while and are in process of switching over to faust-streaming. During this I wanted to find latest pypi package and saw the link is still pointing to the faust pypi package, which could be confusing.

So I corrected the link and while doing that also the small untarring process description below that.

Thanks for the good work.