### PR TITLE
missing `f` prefix on f-string

### DIFF
--- a/faust/streams.py
+++ b/faust/streams.py
@@ -206,7 +206,7 @@ class Stream(StreamT[T_co], Service):
         seen: Set[StreamT] = set()
         while node:
             if node in seen:
-                raise RuntimeError("Loop in Stream.{dir_.attr}: Call support!")
+                raise RuntimeError(f"Loop in Stream.{dir_.attr}: Call support!")
             seen.add(node)
             yield node
             node = dir_.getter(node)


### PR DESCRIPTION
## Description

Clones https://github.com/robinhood/faust/pull/755/files for faust-streaming to fix https://github.com/robinhood/faust/issues/754#issue-1213465684 - which I didn't create for this repo to avoid clutter for such a small fix.