### PR TITLE
add noqa: B024 to base classes to pass lint check

### DIFF
--- a/faust/cli/base.py
+++ b/faust/cli/base.py
@@ -481,7 +481,7 @@ def _prepare_cli(
             os.environ["F_DATADIR"] = datadir
 
 
-class Command(abc.ABC):
+class Command(abc.ABC):  # noqa: B024
     """Base class for subcommands."""
 
     UsageError: Type[Exception] = click.UsageError

--- a/faust/types/models.py
+++ b/faust/types/models.py
@@ -43,7 +43,7 @@ T = TypeVar("T")
 # Workaround for https://bugs.python.org/issue29581
 try:
 
-    @typing.no_type_check  # type: ignore
+    @typing.no_type_check  # type: ignore  # noqa: B024
     class _InitSubclassCheck(metaclass=abc.ABCMeta):  # noqa: B024
         ident: int
 

--- a/faust/types/models.py
+++ b/faust/types/models.py
@@ -44,7 +44,7 @@ T = TypeVar("T")
 try:
 
     @typing.no_type_check  # type: ignore
-    class _InitSubclassCheck(metaclass=abc.ABCMeta):
+    class _InitSubclassCheck(metaclass=abc.ABCMeta):  # noqa: B024
         ident: int
 
         def __init_subclass__(
@@ -54,7 +54,7 @@ try:
             super().__init__(*args, **kwargs)
 
     @typing.no_type_check  # type: ignore
-    class _UsingKwargsInNew(_InitSubclassCheck, ident=909):
+    class _UsingKwargsInNew(_InitSubclassCheck, ident=909):  # noqa: B024
         ...
 
 except TypeError:
@@ -68,7 +68,7 @@ CoercionHandler = Callable[[Any], Any]
 CoercionMapping = MutableMapping[IsInstanceArgT, CoercionHandler]
 
 
-class ModelOptions(abc.ABC):
+class ModelOptions(abc.ABC):  # noqa: B024
     serializer: Optional[CodecArg] = None
     namespace: str
     include_metadata: bool = True

--- a/tests/functional/test_models.py
+++ b/tests/functional/test_models.py
@@ -837,7 +837,7 @@ def test_compat_enabled_blessed_key(app):
 
 
 def test__polymorphic_fields_deeply_nested():
-    class BaseAttribution(Record, abc.ABC):
+    class BaseAttribution(Record, abc.ABC):  # noqa: B024
         def __post_init__(self, *args, **kwargs) -> None:
             self.data_store = None
 
@@ -868,7 +868,7 @@ def test__polymorphic_fields_deeply_nested():
 
 
 def test_compat_blessed_key_deeply_nested():
-    class BaseAttribution(Record, abc.ABC):
+    class BaseAttribution(Record, abc.ABC):  # noqa: B024
         def __post_init__(self, *args, **kwargs) -> None:
             self.data_store = None
 
@@ -934,7 +934,7 @@ ADTRIBUTE_PAYLOAD = """
 
 
 def test_adtribute_payload(app):
-    class BaseAttribution(Record, abc.ABC):
+    class BaseAttribution(Record, abc.ABC):  # noqa: B024
         def __post_init__(self) -> None:
             self.data_store = None
 


### PR DESCRIPTION
Current lints are failing due to an update in `flake8-bugbear`, this will let our tests pass again.