### PR TITLE
version limit mode-streaming while we're working on testing things out

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ aiohttp>=3.5.2,<4.0
 aiohttp_cors>=0.7,<2.0
 aiokafka>=0.7.1,<0.8.0
 click>=6.7,<8.2
-mode-streaming>=0.2.0
+mode-streaming>=0.2.0,<0.3.0
 opentracing>=1.3.0,<=2.4.0
 terminaltables>=3.1,<4.0
 yarl>=1.0,<2.0


### PR DESCRIPTION
This will set us up so that Faust won't use any version of mode-streaming later than 0.2.1.