### PR TITLE
#307: Allow custom headers in self.error view method

### DIFF
--- a/faust/web/views.py
+++ b/faust/web/views.py
@@ -299,9 +299,11 @@ class View:
         """
         return self.error(404, reason, **kwargs)
 
-    def error(self, status: int, reason: str, **kwargs: Any) -> Response:
+    def error(
+        self, status: int, reason: str, headers: MutableMapping = None, **kwargs: Any
+    ) -> Response:
         """Create error JSON response."""
-        return self.json({"error": reason, **kwargs}, status=status)
+        return self.json({"error": reason, **kwargs}, status=status, headers=headers)
 
 
 def takes_model(Model: Type[ModelT]) -> ViewDecorator:

--- a/tests/unit/web/test_views.py
+++ b/tests/unit/web/test_views.py
@@ -204,13 +204,13 @@ class Test_View:
         assert res is handler
 
     def test_error(self, *, view, web):
-        response = view.error(303, "foo", arg="bharg")
+        response = view.error(303, "foo", arg="bharg", headers={"k": "v"})
         web.json.assert_called_once_with(
             {"error": "foo", "arg": "bharg"},
             status=303,
             reason=None,
-            headers=None,
             content_type=None,
+            headers={"k": "v"},
         )
         assert response is web.json()
 


### PR DESCRIPTION
## Description
This PR adds support for custom headers in the `self.error` method when using views. 
This fixes https://github.com/faust-streaming/faust/issues/307.

