### PR TITLE
fix: set loop for services where missing

### DIFF
--- a/extra/tools/verify_doc_defaults.py
+++ b/extra/tools/verify_doc_defaults.py
@@ -15,36 +15,36 @@ import mode
 from yarl import URL
 
 
-SETTINGS: Path = Path('docs/userguide/settings.rst')
+SETTINGS: Path = Path("docs/userguide/settings.rst")
 
-app = faust.App('verify_defaults')
+app = faust.App("verify_defaults")
 
 ignore_settings: Set[str] = {
-    'id',
-    'tabledir',
-    'reply_to',
-    'broker_consumer',
-    'broker_producer',
+    "id",
+    "tabledir",
+    "reply_to",
+    "broker_consumer",
+    "broker_producer",
 }
 
 builtin_locals: Dict[str, Any] = {
-    'aiohttp': aiohttp,
-    'app': app,
-    'datetime': datetime,
-    'datadir': app.conf.datadir,
-    'faust': faust,
-    'logging': logging,
-    'mode': mode,
-    'socket': socket,
-    'timedelta': timedelta,
-    'web_host': socket.gethostname(),
-    'web_port': 6066,
-    'VERSION': faust.__version__,
-    'uuid': uuid,
-    'URL': URL,
+    "aiohttp": aiohttp,
+    "app": app,
+    "datetime": datetime,
+    "datadir": app.conf.datadir,
+    "faust": faust,
+    "logging": logging,
+    "mode": mode,
+    "socket": socket,
+    "timedelta": timedelta,
+    "web_host": socket.gethostname(),
+    "web_port": 6066,
+    "VERSION": faust.__version__,
+    "uuid": uuid,
+    "URL": URL,
 }
 
-RE_REF = re.compile(r'^:(\w+):`')
+RE_REF = re.compile(r"^:(\w+):`")
 
 
 class Error(NamedTuple):
@@ -63,7 +63,7 @@ def verify_settings(rst_path: Path) -> Iterator[Error]:
             actual = actual.value
         if actual != default:
             yield Error(
-                reason='mismatch',
+                reason="mismatch",
                 setting=setting_name,
                 default=default,
                 actual=actual,
@@ -74,14 +74,14 @@ def report_errors(errors: Iterator[Error]) -> int:
     num_errors: int = 0
     for num_errors, e in enumerate(errors, start=1):
         if num_errors == 1:
-            carp(f'{sys.argv[0]}: Errors in docs/userguide/settings.rst:')
-        carp(f'  + Setting {e.reason} {e.setting}:')
-        carp(f'       documentation: {e.default!r}')
-        carp(f'              actual: {e.actual!r}')
+            carp(f"{sys.argv[0]}: Errors in docs/userguide/settings.rst:")
+        carp(f"  + Setting {e.reason} {e.setting}:")
+        carp(f"       documentation: {e.default!r}")
+        carp(f"              actual: {e.actual!r}")
     if num_errors:
-        carp(f'Found {num_errors} error(s).', file=sys.stderr)
+        carp(f"Found {num_errors} error(s).", file=sys.stderr)
     else:
-        print(f'{sys.argv[0]}: All OK :-)', file=sys.stdout)
+        print(f"{sys.argv[0]}: All OK :-)", file=sys.stdout)
     return num_errors
 
 
@@ -89,38 +89,39 @@ def carp(msg, *, file: IO = sys.stderr, **kwargs: Any) -> None:
     print(msg, file=file, **kwargs)
 
 
-def find_settings_in_rst(rst_path: Path,
-                         locals: Dict[str, Any] = None,
-                         builtin_locals: Dict[str, Any] = builtin_locals,
-                         ignore_settings: Set[str] = ignore_settings):
+def find_settings_in_rst(
+    rst_path: Path,
+    locals: Dict[str, Any] = None,
+    builtin_locals: Dict[str, Any] = builtin_locals,
+    ignore_settings: Set[str] = ignore_settings,
+):
     setting: str = None
     default: Any = None
-    app = faust.App('_verify_doc_defaults')
+    app = faust.App("_verify_doc_defaults")
     _globals = dict(globals())
     # Add setting default to globals
     # so that defaults referencing another setting work.
     # E.g.:
     #   :default: :setting:`broker_api_version`
-    _globals.update({
-        name: getattr(app.conf, name)
-        for name in app.conf.setting_names()
-    })
+    _globals.update(
+        {name: getattr(app.conf, name) for name in app.conf.setting_names()}
+    )
     local_ns: Dict[str, Any] = {**builtin_locals, **(locals or {})}
     for line in rst_path.read_text().splitlines():
-        if line.startswith('.. setting::'):
+        if line.startswith(".. setting::"):
             if setting and not default and setting not in ignore_settings:
-                raise Exception(f'No default value for {setting}')
-            setting = line.split('::')[-1].strip()
-        elif ':default:' in line:
-            if '``' in line:
-                line, sep, rest = line.rpartition('``')
-            default = line.split(':default:')[-1].strip()
-            default = default.strip('`')
-            default = RE_REF.sub('', default)
+                raise Exception(f"No default value for {setting}")
+            setting = line.split("::")[-1].strip()
+        elif ":default:" in line:
+            if "``" in line:
+                line, sep, rest = line.rpartition("``")
+            default = line.split(":default:")[-1].strip()
+            default = default.strip("`")
+            default = RE_REF.sub("", default)
             default_value = eval(default, _globals, local_ns)
             if setting not in ignore_settings:
                 yield setting, default_value
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(report_errors(verify_settings(SETTINGS)))

--- a/faust/agents/agent.py
+++ b/faust/agents/agent.py
@@ -1090,7 +1090,6 @@ class Agent(AgentT, Service):
 
 
 class AgentTestWrapper(Agent, AgentTestWrapperT):  # pragma: no cover
-
     _stream: StreamT
 
     def __init__(

--- a/faust/agents/agent.py
+++ b/faust/agents/agent.py
@@ -226,7 +226,7 @@ class Agent(AgentT, Service):
                 "Agent concurrency must be 1 when using isolated partitions"
             )
         self.use_reply_headers = use_reply_headers
-        Service.__init__(self)
+        Service.__init__(self, loop=app.loop)
 
     def on_init_dependencies(self) -> Iterable[ServiceT]:
         """Return list of services dependencies required to start agent."""

--- a/faust/cli/base.py
+++ b/faust/cli/base.py
@@ -527,6 +527,7 @@ class Command(abc.ABC):  # noqa: B024
     @classmethod
     def as_click_command(cls) -> Callable:  # pragma: no cover
         """Convert command into :pypi:`click` command."""
+
         # This is what actually registers the commands into the
         # :pypi:`click` command-line interface (the ``def cli`` main above).
         # __init_subclass__ calls this for the side effect of being

--- a/faust/livecheck/case.py
+++ b/faust/livecheck/case.py
@@ -176,7 +176,7 @@ class Case(Service):
         # signal attributes have the correct signal instance.
         self.__dict__.update(self.signals)
 
-        Service.__init__(self, **kwargs)
+        Service.__init__(self, loop=app.loop, **kwargs)
 
     @Service.timer(10.0)
     async def _sampler(self) -> None:

--- a/faust/models/fields.py
+++ b/faust/models/fields.py
@@ -331,7 +331,6 @@ class BooleanField(FieldDescriptor[bool]):
 
 
 class NumberField(FieldDescriptor[T]):
-
     max_value: Optional[int]
     min_value: Optional[int]
 
@@ -439,7 +438,6 @@ class DecimalField(NumberField[Decimal]):
 
 
 class CharField(FieldDescriptor[CharacterType]):
-
     max_length: Optional[int]
     min_length: Optional[int]
     trim_whitespace: bool

--- a/faust/models/tags.py
+++ b/faust/models/tags.py
@@ -79,7 +79,6 @@ class TransparentTag(Tag[T]):
 
 
 class _FrameLocal(UserString, Generic[T]):
-
     _field_name: str
     _tag_type: str
     _frame: str

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -866,7 +866,6 @@ class Stream(StreamT[T_co], Service):
         if topic is not None:
             channel = topic
         else:
-
             prefix = ""
             if self.prefix and not cast(TopicT, self.channel).has_prefix:
                 prefix = self.prefix + "-"

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -125,7 +125,7 @@ class Collection(Service, CollectionT):
         synchronize_all_active_partitions: bool = False,
         **kwargs: Any,
     ) -> None:
-        Service.__init__(self, **kwargs)
+        Service.__init__(self, loop=app.loop, **kwargs)
         self.app = app
         self.name = cast(str, name)  # set lazily so CAN BE NONE!
         self.default = default

--- a/faust/tables/objects.py
+++ b/faust/tables/objects.py
@@ -72,7 +72,7 @@ class ChangeloggedObjectManager(Store):
         self.table_name = self.table.name
         self.data = {}
         self._dirty = set()
-        Service.__init__(self, **kwargs)
+        Service.__init__(self, loop=table.loop, **kwargs)
 
     def send_changelog_event(self, key: Any, operation: int, value: Any) -> None:
         """Send changelog event to the tables changelog topic."""

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -1363,7 +1363,6 @@ class ConsumerThread(QueueServiceThread):
 
 
 class ThreadDelegateConsumer(Consumer):
-
     _thread: ConsumerThread
 
     #: Main thread method queue.

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -1146,7 +1146,6 @@ class Producer(base.Producer):
         """Commit transaction by id."""
         try:
             async with self._trn_locks[transactional_id]:
-
                 transaction_producer = self._transaction_producers.get(transactional_id)
                 if transaction_producer:
                     await transaction_producer.commit_transaction()
@@ -1170,7 +1169,6 @@ class Producer(base.Producer):
         """Abort and rollback transaction by id."""
         try:
             async with self._trn_locks[transactional_id]:
-
                 transaction_producer = self._transaction_producers.get(transactional_id)
                 if transaction_producer:
                     await transaction_producer.abort_transaction()
@@ -1210,7 +1208,6 @@ class Producer(base.Producer):
         for transactional_id, offsets in tid_to_offset_map.items():
             # get the producer
             async with self._trn_locks[transactional_id]:
-
                 transaction_producer = self._transaction_producers.get(transactional_id)
                 if transaction_producer:
                     logger.debug(
@@ -1346,7 +1343,6 @@ class Producer(base.Producer):
         try:
             if transactional_id:
                 async with self._trn_locks[transactional_id]:
-
                     return cast(
                         Awaitable[RecordMetadata],
                         await transaction_producer.send(

--- a/faust/types/agents.py
+++ b/faust/types/agents.py
@@ -72,7 +72,6 @@ ReplyToArg = Union["AgentT", ChannelT, str]
 
 
 class ActorT(ServiceT, Generic[_T]):
-
     agent: "AgentT"
     stream: StreamT
     it: _T
@@ -122,7 +121,6 @@ ActorRefT = ActorT[Union[AsyncIterable, Awaitable]]
 
 
 class AgentT(ServiceT, Generic[_T]):
-
     name: str
     app: _AppT
     concurrency: int
@@ -325,7 +323,6 @@ class AgentManagerT(ServiceT, ManagedUserDict[str, AgentT]):
 
 
 class AgentTestWrapperT(AgentT, AsyncIterable):
-
     new_value_processed: asyncio.Condition
     original_channel: ChannelT
     results: MutableMapping[int, Any]

--- a/faust/types/assignor.py
+++ b/faust/types/assignor.py
@@ -27,7 +27,6 @@ HostToPartitionMap = MutableMapping[str, TopicToPartitionMap]
 
 
 class PartitionAssignorT(abc.ABC):
-
     replicas: int
     app: _AppT
 
@@ -69,7 +68,6 @@ class PartitionAssignorT(abc.ABC):
 
 
 class LeaderAssignorT(ServiceT):
-
     app: _AppT
 
     @abc.abstractmethod

--- a/faust/types/events.py
+++ b/faust/types/events.py
@@ -28,7 +28,6 @@ T = TypeVar("T")
 
 
 class EventT(Generic[T], AsyncContextManager):
-
     app: _AppT
     key: K
     value: V

--- a/faust/types/fixups.py
+++ b/faust/types/fixups.py
@@ -14,7 +14,6 @@ __all__ = ["FixupT"]
 
 
 class FixupT(abc.ABC):
-
     app: _AppT
 
     @abc.abstractmethod

--- a/faust/types/models.py
+++ b/faust/types/models.py
@@ -194,7 +194,6 @@ class ModelT(base):  # type: ignore
 
 
 class FieldDescriptorT(Generic[T]):
-
     field: str
     input_name: str
     output_name: str

--- a/faust/types/sensors.py
+++ b/faust/types/sensors.py
@@ -147,7 +147,6 @@ class SensorT(SensorInterfaceT, ServiceT):
 
 
 class SensorDelegateT(SensorInterfaceT, Iterable):
-
     # Delegate calls to many sensors.
 
     @abc.abstractmethod

--- a/faust/types/serializers.py
+++ b/faust/types/serializers.py
@@ -28,7 +28,6 @@ VT = TypeVar("VT")
 
 
 class RegistryT(abc.ABC):
-
     key_serializer: CodecArg
     value_serializer: CodecArg
 
@@ -72,7 +71,6 @@ class RegistryT(abc.ABC):
 
 
 class SchemaT(Generic[KT, VT]):
-
     key_type: Optional[_ModelArg] = None
     value_type: Optional[_ModelArg] = None
 

--- a/faust/types/stores.py
+++ b/faust/types/stores.py
@@ -33,7 +33,6 @@ VT = TypeVar("VT")
 
 
 class StoreT(ServiceT, FastUserDict[KT, VT]):
-
     url: URL
     app: _AppT
     table: _CollectionT

--- a/faust/types/streams.py
+++ b/faust/types/streams.py
@@ -104,7 +104,6 @@ class JoinableT(abc.ABC):
 
 
 class StreamT(AsyncIterable[T_co], JoinableT, ServiceT):
-
     app: _AppT
     channel: AsyncIterator[T_co]
     outbox: Optional[asyncio.Queue] = None

--- a/faust/types/topics.py
+++ b/faust/types/topics.py
@@ -30,7 +30,6 @@ __all__ = ["TopicT"]
 
 
 class TopicT(ChannelT):
-
     #: Iterable/Sequence of topic names to subscribe to.
     topics: Sequence[str]
 

--- a/faust/types/transports.py
+++ b/faust/types/transports.py
@@ -78,7 +78,6 @@ PartitionerT = Callable[
 
 
 class ProducerBufferT(ServiceT):
-
     max_messages: int
 
     pending: asyncio.Queue
@@ -106,7 +105,6 @@ class ProducerBufferT(ServiceT):
 
 
 class ProducerT(ServiceT):
-
     #: The transport that created this Producer.
     transport: "TransportT"
 
@@ -289,7 +287,6 @@ class SchedulingStrategyT:
 
 
 class ConsumerT(ServiceT):
-
     #: The transport that created this Consumer.
     transport: "TransportT"
 
@@ -451,7 +448,6 @@ class ConsumerT(ServiceT):
 
 
 class ConductorT(ServiceT, MutableSet[TopicT]):
-
     # The topic conductor delegates messages from the Consumer
     # to the various Topic instances subscribed to a topic.
 
@@ -492,7 +488,6 @@ class ConductorT(ServiceT, MutableSet[TopicT]):
 
 
 class TransportT(abc.ABC):
-
     #: The Consumer class used for this type of transport.
     Consumer: ClassVar[Type[ConsumerT]]
 

--- a/faust/types/tuples.py
+++ b/faust/types/tuples.py
@@ -113,7 +113,6 @@ def _get_len(s: Optional[bytes]) -> int:
 
 
 class Message:
-
     __slots__ = (
         "topic",
         "partition",

--- a/faust/types/web.py
+++ b/faust/types/web.py
@@ -96,7 +96,6 @@ class ResourceOptions(NamedTuple):
 
 
 class CacheBackendT(ServiceT):
-
     Unavailable: Type[BaseException]
 
     @abc.abstractmethod
@@ -121,7 +120,6 @@ class CacheBackendT(ServiceT):
 
 
 class CacheT(abc.ABC):
-
     timeout: Optional[Seconds]
     include_headers: bool
     key_prefix: str

--- a/faust/web/base.py
+++ b/faust/web/base.py
@@ -186,7 +186,7 @@ class Web(Service):
         else:
             blueprints.extend(self.production_blueprints)
         self.blueprints = BlueprintManager(blueprints)
-        Service.__init__(self, **kwargs)
+        Service.__init__(self, loop=app.loop, **kwargs)
 
     @abc.abstractmethod
     def text(

--- a/tests/functional/test_models.py
+++ b/tests/functional/test_models.py
@@ -939,7 +939,6 @@ def test_adtribute_payload(app):
             self.data_store = None
 
     class AdjustData(Record):
-
         activity_kind: str
         network_name: str
         adid: str
@@ -998,7 +997,6 @@ def test_adtribute_payload(app):
 
 
 def test_overwrite_asdict():
-
     with pytest.raises(RuntimeError):
 
         class R(Record):
@@ -1115,7 +1113,6 @@ def test_abstract_model_repr():
 
 
 def test_raises_when_defaults_in_wrong_order():
-
     with pytest.raises(TypeError):
 
         class X(Record):

--- a/tests/stress/killer.py
+++ b/tests/stress/killer.py
@@ -19,7 +19,6 @@ class Span(NamedTuple):
 
 
 class Chaos(Service):
-
     schedule = [
         # Signal -TERM/-INT between every 1 and 30 seconds.
         # This period lasts for at least half a minute, but never for more

--- a/tests/stress/reports/logging.py
+++ b/tests/stress/reports/logging.py
@@ -12,7 +12,6 @@ from .models import Error
 
 
 class LogPusher(Service):
-
     app: faust.App
     queue: asyncio.Queue
 
@@ -36,7 +35,6 @@ class LogPusher(Service):
 
 
 class LogHandler(logging.Handler):
-
     app: faust.App
 
     def __init__(self, app: faust.App, *args: Any, **kwargs: Any) -> None:

--- a/tests/stress/reports/models.py
+++ b/tests/stress/reports/models.py
@@ -6,7 +6,6 @@ __all__ = ["Error", "Status"]
 
 
 class Error(faust.Record):
-
     #: Message (the actual formatted log message).
     message: str
 
@@ -39,7 +38,6 @@ class Error(faust.Record):
 
 
 class Status(faust.Record):
-
     #: The id of the app that is sending this.
     app_id: str
 

--- a/tests/unit/agents/test_actor.py
+++ b/tests/unit/agents/test_actor.py
@@ -18,7 +18,6 @@ class FakeActor(Actor):
 
 
 class Test_Actor:
-
     ActorType = FakeActor
 
     @pytest.fixture()
@@ -94,7 +93,6 @@ class Test_Actor:
 
 
 class Test_AsyncIterableActor(Test_Actor):
-
     ActorType = AsyncIterableActor
 
     def test_aiter(self, *, actor, it):
@@ -104,7 +102,6 @@ class Test_AsyncIterableActor(Test_Actor):
 
 
 class Test_AwaitableActor(Test_Actor):
-
     ActorType = AwaitableActor
 
     def test_await(self, *, actor, it):

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -828,7 +828,6 @@ class Test_App:
         assert isinstance(app.tables.data["name"], GlobalTableT)
 
     def test_page(self, *, app):
-
         with patch("faust.app.base.venusian") as venusian:
 
             @app.page("/foo")
@@ -840,7 +839,6 @@ class Test_App:
             venusian.attach.assert_called_once_with(view, category=SCAN_PAGE)
 
     def test_page__with_cors_options(self, *, app):
-
         with patch("faust.app.base.venusian") as venusian:
 
             @app.page(

--- a/tests/unit/livecheck/patches/test_aiohttp.py
+++ b/tests/unit/livecheck/patches/test_aiohttp.py
@@ -9,7 +9,6 @@ from faust.livecheck.patches.aiohttp import LiveCheckMiddleware, patch_aiohttp_s
 
 @pytest.mark.asyncio
 async def test_patch_aiohttp_session(*, execution):
-
     patch_aiohttp_session()
     from aiohttp.client import ClientSession
 

--- a/tests/unit/livecheck/test_app.py
+++ b/tests/unit/livecheck/test_app.py
@@ -113,7 +113,6 @@ class Test_LiveCheck:
 
         @livecheck.case()
         class Test_foo:
-
             signal1: livecheck.Signal
             signal2: SignalWithNoneOrigin
             signal3: livecheck.Signal = livecheck.Signal()

--- a/tests/unit/stores/test_aerospike.py
+++ b/tests/unit/stores/test_aerospike.py
@@ -100,7 +100,6 @@ class TestAerospikeStore:
         store,
     ):
         with patch("faust.stores.aerospike.aerospike", MagicMock()) as aero:
-
             store.client.put = MagicMock()
             key = b"key"
             value = b"value"
@@ -198,7 +197,6 @@ class TestAerospikeStore:
 
     def test_iteritems_success(self, store):
         with patch("faust.stores.aerospike.aerospike", MagicMock()):
-
             scan = MagicMock()
             store.client.scan = MagicMock(return_value=scan)
             scan_result = [

--- a/tests/unit/stores/test_rocksdb.py
+++ b/tests/unit/stores/test_rocksdb.py
@@ -365,7 +365,6 @@ class Test_Store:
         return db
 
     def test_get_bucket_for_key__not_in_index(self, *, store):
-
         dbs = {
             1: self.new_db(name="db1"),
             2: self.new_db(name="db2"),

--- a/tests/unit/tables/test_base.py
+++ b/tests/unit/tables/test_base.py
@@ -188,7 +188,6 @@ class Test_Collection:
 
     @pytest.mark.asyncio
     async def test_last_closed_window(self, *, table):
-
         assert table.last_closed_window == 0.0
 
         table.window = Mock(name="window")

--- a/tests/unit/transport/drivers/test_aiokafka.py
+++ b/tests/unit/transport/drivers/test_aiokafka.py
@@ -529,7 +529,6 @@ class Test_VEP_no_highwater_since_start(Test_verify_event_path_base):
 
 @pytest.mark.skip("Needs fixing")
 class Test_VEP_stream_idle_no_highwater(Test_verify_event_path_base):
-
     highwater = 10
     committed_offset = 10
 

--- a/tests/unit/transport/test_producer.py
+++ b/tests/unit/transport/test_producer.py
@@ -121,7 +121,6 @@ class TestProducerBuffer:
 
     @pytest.mark.asyncio
     async def test_flush_atmost(self, *, buf):
-
         sent_messages = 0
 
         def create_send_pending_mock(max_messages):


### PR DESCRIPTION
Some services do still start a different / new loop or do not pass the loop param to their super Service call. This brings issues when using faust in other frameworks and using third party loops, e.g. fastapi + uvloop

Sorry I did miss some in the last merge request, but I think I did catch all now. Feel free to check twice 😊 

Fixes https://github.com/faust-streaming/faust/issues/435