### PR TITLE
Fix spelling of NLTK

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ increase once we can support a more optimized Kafka client.
 Faust is just Python, and a stream is an infinite asynchronous iterator.
 If you know how to use Python, you already know how to use Faust,
 and it works with your favorite Python libraries like Django, Flask,
-SQLAlchemy, NTLK, NumPy, SciPy, TensorFlow, etc.
+SQLAlchemy, NLTK, NumPy, SciPy, TensorFlow, etc.
 
 ## Bundles
 

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -58,4 +58,4 @@
     Faust is just Python, and a stream is an infinite asynchronous iterator.
     If you know how to use Python, you already know how to use Faust,
     and it works with your favorite Python libraries like Django, Flask,
-    SQLAlchemy, NTLK, NumPy, SciPy, TensorFlow, etc.
+    SQLAlchemy, NLTK, NumPy, SciPy, TensorFlow, etc.


### PR DESCRIPTION
## Description

Small typo fix NTLK -> NLTK (https://github.com/nltk/nltk)