### PR TITLE
Update pip installs from remaining faust to faust-streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Using `eventlet` requires you to install the `faust-aioeventlet` module,
 and you can install this as a bundle along with Faust:
 
 ```sh
-pip install -U faust[eventlet]
+pip install -U faust-streaming[eventlet]
 ```
 
 Then to actually use eventlet as the event loop you have to either

--- a/docs/includes/faq.txt
+++ b/docs/includes/faq.txt
@@ -18,7 +18,7 @@ and you can install this as a bundle along with Faust:
 
 .. sourcecode:: console
 
-    $ pip install -U faust[eventlet]
+    $ pip install -U faust-streaming[eventlet]
 
 Then to actually use eventlet as the event loop you have to either
 use the :option:`-L <faust --loop>` argument to the :program:`faust` program:

--- a/docs/includes/installation.txt
+++ b/docs/includes/installation.txt
@@ -8,7 +8,7 @@ To install using `pip`:
 
 .. sourcecode:: console
 
-    $ pip install -U faust
+    $ pip install -U faust-streaming
 
 .. _bundles:
 
@@ -23,9 +23,9 @@ command-line by using brackets. Separate multiple bundles using the comma:
 
 .. sourcecode:: console
 
-    $ pip install "faust[rocksdb]"
+    $ pip install "faust-streaming[rocksdb]"
 
-    $ pip install "faust[rocksdb,uvloop,fast,redis]"
+    $ pip install "faust-streaming[rocksdb,uvloop,fast,redis]"
 
 The following bundles are available:
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -174,53 +174,53 @@ Extensions
 +--------------+-------------+--------------------------------------------------+
 | **Name**     | **Version** | **Bundle**                                       |
 +--------------+-------------+--------------------------------------------------+
-| ``rocksdb``  | 5.0         | ``pip install faust[rocksdb]``                   |
+| ``rocksdb``  | 5.0         | ``pip install faust-streaming[rocksdb]``         |
 +--------------+-------------+--------------------------------------------------+
-| ``redis``    | aredis 1.1  | ``pip install faust[redis]``                     |
+| ``redis``    | aredis 1.1  | ``pip install faust-streaming[redis]``           |
 +--------------+-------------+--------------------------------------------------+
-| ``datadog``  | 0.20.0      | ``pip install faust[datadog]``                   |
+| ``datadog``  | 0.20.0      | ``pip install faust-streaming[datadog]``         |
 +--------------+-------------+--------------------------------------------------+
-| ``statsd``   | 3.2.1       | ``pip install faust[statsd]``                    |
+| ``statsd``   | 3.2.1       | ``pip install faust-streaming[statsd]``          |
 +--------------+-------------+--------------------------------------------------+
-| ``uvloop``   | 0.8.1       | ``pip install faust[uvloop]``                    |
+| ``uvloop``   | 0.8.1       | ``pip install faust-streaming[uvloop]``          |
 +--------------+-------------+--------------------------------------------------+
-| ``eventlet`` | 1.16.0      | ``pip install faust[eventlet]``                  |
+| ``eventlet`` | 1.16.0      | ``pip install faust-streaming[eventlet]``        |
 +--------------+-------------+--------------------------------------------------+
-| ``yaml``     | 5.1.0       | ``pip install faust[yaml]``                      |
+| ``yaml``     | 5.1.0       | ``pip install faust-streaming[yaml]``            |
 +--------------+-------------+--------------------------------------------------+
 
 Optimizations
 -------------
 
-These can be all installed using ``pip install faust[fast]``:
+These can be all installed using ``pip install faust-streaming[fast]``:
 
 +------------------+-------------+--------------------------------------------------+
 | **Name**         | **Version** | **Bundle**                                       |
 +------------------+-------------+--------------------------------------------------+
-| ``aiodns``       | 1.1.0       | ``pip install faust[aiodns]``                    |
+| ``aiodns``       | 1.1.0       | ``pip install faust-streaming[aiodns]``          |
 +------------------+-------------+--------------------------------------------------+
-| ``cchardet``     | 1.1.0       | ``pip install faust[cchardet]``                  |
+| ``cchardet``     | 1.1.0       | ``pip install faust-streaming[cchardet]``        |
 +------------------+-------------+--------------------------------------------------+
-| ``ciso8601``     | 2.1.0       | ``pip install faust[ciso8601]``                  |
+| ``ciso8601``     | 2.1.0       | ``pip install faust-streaming[ciso8601]``        |
 +------------------+-------------+--------------------------------------------------+
-| ``cython``       | 0.9.26      | ``pip install faust[cython]``                    |
+| ``cython``       | 0.9.26      | ``pip install faust-straming[cython]``           |
 +------------------+-------------+--------------------------------------------------+
-| ``orjson``       | 2.0.0       | ``pip install faust[orjson]``                    |
+| ``orjson``       | 2.0.0       | ``pip install faust-streaming[orjson]``          |
 +------------------+-------------+--------------------------------------------------+
-| ``setproctitle`` | 1.1.0       | ``pip install faust[setproctitle]``              |
+| ``setproctitle`` | 1.1.0       | ``pip install faust-streaming[setproctitle]``    |
 +------------------+-------------+--------------------------------------------------+
 
 Debugging extras
 ----------------
 
-These can be all installed using ``pip install faust[debug]``:
+These can be all installed using ``pip install faust-streaming[debug]``:
 
 +------------------+-------------+--------------------------------------------------+
 | **Name**         | **Version** | **Bundle**                                       |
 +------------------+-------------+--------------------------------------------------+
-| ``aiomonitor``   | 0.3         | ``pip install faust[aiomonitor]``                |
+| ``aiomonitor``   | 0.3         | ``pip install faust-streaming[aiomonitor]``      |
 +------------------+-------------+--------------------------------------------------+
-| ``setproctitle`` | 1.1.0       | ``pip install faust[setproctitle]``              |
+| ``setproctitle`` | 1.1.0       | ``pip install faust-streaming[setproctitle]``    |
 +------------------+-------------+--------------------------------------------------+
 
 .. note::
@@ -234,7 +234,7 @@ These can be all installed using ``pip install faust[debug]``:
 
     .. sourcecode:: console
 
-        $ pip install faust[uvloop,fast,rocksdb,datadog,redis]
+        $ pip install faust-streaming[uvloop,fast,rocksdb,datadog,redis]
 
 .. admonition:: RocksDB On MacOS Sierra
 

--- a/docs/userguide/debugging.rst
+++ b/docs/userguide/debugging.rst
@@ -27,7 +27,7 @@ You can also install it as part of a :ref:`bundle <bundles>`:
 
 .. sourcecode:: console
 
-    $ pip install -U faust[debug]
+    $ pip install -U faust-streaming[debug]
 
 
 After :pypi:`aiomonitor` is installed you may start the worker with the


### PR DESCRIPTION
Replace `pip install faust` by `pip install faust-streaming` inside the documentation (mainly) and one remaining inside the README.