### PR TITLE
Remove pytest-openfiles due to deprecation

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,7 +12,6 @@ pytest-aiofiles>=0.2.0
 pytest-aiohttp>=0.3.0
 pytest-asyncio
 pytest-forked
-pytest-openfiles>=0.2.0
 pytest-picked
 pytest-cov
 pytest-random-order>=0.5.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,5 +20,7 @@ addopts =
   -rxXs
   --strict-config
   --strict-markers
+filterwarnings =
+    error::ResourceWarning
 xfail_strict=True
 


### PR DESCRIPTION
Closes #463.
