### PR TITLE
Bump click requirement to <9.0

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.8.3,<4.0
 aiohttp_cors>=0.7,<2.0
 aiokafka>=0.8.0,<0.9.0
-click>=6.7,<8.2
+click>=6.7,<9.0
 mode-streaming>=0.3.0
 opentracing>=1.3.0,<=2.4.0
 terminaltables>=3.1,<4.0


### PR DESCRIPTION
Saw this in https://github.com/robinhood/faust/pull/773, figured I'd change things here.