### PR TITLE
Bump rocksdict minimum requirement to 0.3.7

### DIFF
--- a/requirements/extras/rocksdict.txt
+++ b/requirements/extras/rocksdict.txt
@@ -1,1 +1,1 @@
-rocksdict<=0.3.2
+rocksdict>=0.3.7


### PR DESCRIPTION
`rocksdict` 0.3.2 and 0.3.7 are safe versions to use, so let's go ahead and skip ahead to 0.3.7.