### PR TITLE
Add support for comma separated list of urls

### DIFF
--- a/faust/utils/urls.py
+++ b/faust/utils/urls.py
@@ -19,8 +19,8 @@ def urllist(arg: URIListArg, *, default_scheme: Optional[str] = None) -> List[UR
         # handle scalar URL argument.
         arg = [arg]
     elif isinstance(arg, str):
-        # Handle scalar str, including semi-colon separated lists of URLs.
-        urls = arg.split(";")
+        # Handle scalar str, including comma and semi-colon separated lists of URLs.
+        urls = arg.replace(",", ";").split(";")
 
         # When some of the URLs do not have a scheme, we use
         # the first scheme we find as the default scheme.

--- a/tests/unit/utils/test_urls.py
+++ b/tests/unit/utils/test_urls.py
@@ -49,6 +49,14 @@ def test_urllist_strsep():
     ]
 
 
+def test_urllist_strsep_comma():
+    assert urllist("foo://localhost,bar.com,example.com") == [
+        URL("foo://localhost"),
+        URL("foo://bar.com"),
+        URL("foo://example.com"),
+    ]
+
+
 def test_urllist_strsep_no_scheme():
     assert urllist("localhost;bar.com;example.com", default_scheme="bar") == [
         URL("bar://localhost"),


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust-streaming.github.io/faust/contributing.html).

## Description

Allow using a comma separated list of brokers URLs in addition to semi-colon
Comma separated list is widely used in most kafka packages

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
