### PR TITLE
Ack filtered messages when using .take()

### DIFF
--- a/faust/_cython/streams.pyx
+++ b/faust/_cython/streams.pyx
@@ -109,8 +109,7 @@ cdef class StreamIterator:
             object consumer
         consumer = self.consumer
         last_stream_to_ack = False
-        # if do_ack and event is not None:
-        if event is not None and (do_ack or event.value is self._skipped_value):
+        if do_ack and event is not None:
             message = event.message
             if not message.acked:
                 refcount = message.refcount

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -1065,7 +1065,7 @@ class Stream(StreamT[T_co], Service):
                         yield value
                 finally:
                     event, self.current_event = self.current_event, None
-                    it.after(event, do_ack, sensor_state)
+                    it.after(event, do_ack or value is skipped_value, sensor_state)
         except StopAsyncIteration:
             # We are not allowed to propagate StopAsyncIteration in __aiter__
             # (if we do, it'll be converted to RuntimeError by CPython).

--- a/tests/functional/test_streams.py
+++ b/tests/functional/test_streams.py
@@ -1,6 +1,6 @@
 import asyncio
 from copy import copy
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from mode import label
@@ -234,6 +234,30 @@ async def test_stream_filter_acks_filtered_out_messages(app, event_loop):
         async for event in stream.events():
             assert event.value > 1000
     assert len(app.consumer.unacked) == 0
+
+
+@pytest.mark.asyncio
+async def test_acks_filtered_out_messages_when_using_take(app, event_loop):
+    """
+    Test the filter function acknowledges the filtered out messages when using take().
+    """
+    initial_values = [1000, 999, 3000, 99, 5000, 3, 9999]
+    expected_values = [v for v in initial_values if v > 1000]
+    original_function = app.create_event
+    # using patch to intercept message objects, to check if they are acked later
+    with patch("faust.app.base.App.create_event") as create_event_mock:
+        create_event_mock.side_effect = original_function
+        async with new_stream(app) as stream:
+            for value in initial_values:
+                await stream.channel.send(value=value)
+            async for values in stream.filter(lambda x: x > 1000).take(
+                len(expected_values), within=5
+            ):
+                assert values == expected_values
+                break
+    messages = [call[0][3] for call in create_event_mock.call_args_list]
+    acked = [m.acked for m in messages if m.acked]
+    assert len(acked) == len(initial_values)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The issue:
When using filter().take() chain, the filtered out messages are not getting acked (if `NO_CYTHON=False`).
There has been a PR #208 which aimed to fix the same issue, but it only fixed it for installations that don't use `cython`. For `NO_CYTHON=False` this solution didn't work.

Solution:
Compare the message value to the `skipped_value` and ack it.

Note:
The test I added runs red before fix and green after fix. It may look a little bit clumsy but it shows the issue.
Any suggestions are welcome.