### PR TITLE
Change requirements to set 3.8.0 as minimum aiohttp version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.8.3,<4.0
+aiohttp>=3.8.0,<4.0
 aiohttp_cors>=0.7,<2.0
 aiokafka>=0.8.0,<0.9.0
 click>=6.7,<8.2


### PR DESCRIPTION
Closes #484.
