### PR TITLE
Remove extraneous sleep in SetManager.flush

### DIFF
--- a/faust/tables/objects.py
+++ b/faust/tables/objects.py
@@ -142,7 +142,6 @@ class ChangeloggedObjectManager(Store):
     @Service.task
     async def _periodic_flush(self) -> None:  # pragma: no cover
         async for sleep_time in self.itertimer(2.0, name="SetManager.flush"):
-            await self.sleep(sleep_time)
             self.flush_to_storage()
 
     def reset_state(self) -> None:


### PR DESCRIPTION
## Description

This issue has popped up before:

https://github.com/robinhood/faust/issues/549
https://github.com/faust-streaming/faust/issues/77

The 2nd report was resolved by someone editing their local copy to remove the `sleep` call. The issue persists in the main repo, since `itertimer` already sleeps, and the extra `sleep` generates warnings

Fixes #77