### PR TITLE
End support for Python 3.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
       # for example if a test fails only when Cython is enabled
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: [3.8", "3.9", "3.10", "3.11"]
         use-cython: ["true", "false"]
     env:
       USE_CYTHON: ${{ matrix.use-cython }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
       # for example if a test fails only when Cython is enabled
       fail-fast: false
       matrix:
-        python-version: [3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         use-cython: ["true", "false"]
     env:
       USE_CYTHON: ${{ matrix.use-cython }}

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Yes! Use the `asyncio` reactor implementation: https://twistedmatrix.com/documen
 
 ### Will you support Python 2.7 or Python 3.5
 
-No. Faust requires Python 3.7 or later, since it heavily uses features that were
+No. Faust requires Python 3.8 or later, since it heavily uses features that were
 introduced in Python 3.6 (`async`, `await`, variable type annotations).
 
 ### I get a maximum number of open files exceeded error by RocksDB when running a Faust app locally. How can I fix this

--- a/docs/includes/faq.txt
+++ b/docs/includes/faq.txt
@@ -55,7 +55,7 @@ https://twistedmatrix.com/documents/17.1.0/api/twisted.internet.asyncioreactor.h
 Will you support Python 2.7 or Python 3.5?
 ------------------------------------------
 
-No. Faust requires Python 3.7 or later, since it heavily uses features that were
+No. Faust requires Python 3.8 or later, since it heavily uses features that were
 introduced in Python 3.6 (`async`, `await`, variable type annotations).
 
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -155,14 +155,14 @@ What do I need?
 
     **Core**
 
-    - Python 3.7 or later.
+    - Python 3.8 or later.
     - Kafka 0.10.1 or later.
 
     **Extensions**
 
     - RocksDB 5.0 or later, :pypi:`python-rocksdb`
 
-Faust requires Python 3.7 or later, and a running Kafka broker.
+Faust requires Python 3.8 or later, and a running Kafka broker.
 
 There's no plan to support earlier Python versions.
 Please get in touch if this is something you want to work on.

--- a/docs/userguide/application.rst
+++ b/docs/userguide/application.rst
@@ -1374,7 +1374,7 @@ setuptools to install a command-line program for your project.
             include_package_data=True,
             zip_safe=False,
             install_requires=['faust'],
-            python_requires='~=3.7',
+            python_requires='~=3.8',
         )
 
     For inspiration you can also look to the `setup.py` files in the

--- a/examples/django/setup.py
+++ b/examples/django/setup.py
@@ -95,7 +95,7 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['ez_setup', 'tests', 'tests.*']),
     include_package_data=True,
-    python_requires='>=3.7.0',
+    python_requires='>=3.8.0',
     keywords=[],
     zip_safe=False,
     install_requires=reqs('default.txt'),

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ LIBRARIES = []
 E_UNSUPPORTED_PYTHON = NAME + " 1.0 requires Python %%s or later!"
 
 if sys.version_info < (3, 7):
-    raise Exception(E_UNSUPPORTED_PYTHON % ("3.7",))  # NOQA
+    raise Exception(E_UNSUPPORTED_PYTHON % ("3.8",))  # NOQA
 
 from pathlib import Path  # noqa
 
@@ -197,7 +197,7 @@ def do_setup(**kwargs):
         # PEP-561: https://www.python.org/dev/peps/pep-0561/
         package_data={"faust": ["py.typed"]},
         include_package_data=True,
-        python_requires=">=3.7.0",
+        python_requires=">=3.8.0",
         zip_safe=False,
         install_requires=reqs("requirements.txt"),
         tests_require=reqs("test.txt"),
@@ -228,7 +228,6 @@ def do_setup(**kwargs):
             "License :: OSI Approved :: BSD License",
             "Programming Language :: Python",
             "Programming Language :: Python :: 3 :: Only",
-            "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = 3.11,3.10,3.9,3.8,3.7,flake8,apicheck,configcheck,typecheck,docstyle,bandit,spell
+envlist = 3.11,3.10,3.9,3.8,flake8,apicheck,configcheck,typecheck,docstyle,bandit,spell
 
 [testenv]
 deps=
@@ -21,7 +21,6 @@ basepython =
     3.10,flake8,apicheck,linkcheck,configcheck,typecheck,docstyle,bandit,spell: python3.10
     3.9,flake8,apicheck,linkcheck,configcheck,typecheck,docstyle,bandit,spell: python3.9
     3.8,flake8,apicheck,linkcheck,configcheck,typecheck,docstyle,bandit,spell: python3.8
-    3.7,flake8,apicheck,linkcheck,configcheck,typecheck,docstyle,bandit,spell: python3.7
 
 [testenv:apicheck]
 setenv =


### PR DESCRIPTION
Since Python 3.7 is getting EOL'ed in a month, and https://github.com/faust-streaming/faust/pull/506 + https://github.com/faust-streaming/faust/pull/507 indicate that core dependencies in our pipelines are broken for 3.7, we should go ahead and end support.
