### PR TITLE
Ensure callback map is rebuilt after reply_to topics are created

### DIFF
--- a/faust/agents/replies.py
+++ b/faust/agents/replies.py
@@ -174,8 +174,8 @@ class ReplyConsumer(Service):
             self._fetchers[topic_name] = None
             # declare the topic
             topic = self._reply_topic(topic_name)
-            self.app.topics.add(topic)
             await topic.maybe_declare()
+            self.app.topics.add(topic)
             await self.sleep(3.0)
             # then create the future
             self._fetchers[topic_name] = self.add_future(self._drain_replies(topic))

--- a/faust/agents/replies.py
+++ b/faust/agents/replies.py
@@ -174,6 +174,7 @@ class ReplyConsumer(Service):
             self._fetchers[topic_name] = None
             # declare the topic
             topic = self._reply_topic(topic_name)
+            self.app.topics.add(topic)
             await topic.maybe_declare()
             await self.sleep(3.0)
             # then create the future

--- a/faust/transport/conductor.py
+++ b/faust/transport/conductor.py
@@ -338,10 +338,6 @@ class Conductor(ConductorT, Service):
                     self._acking_topics.add(topic)
                 self._topic_name_index[topic].add(channel)
 
-        if self.app.client_only:
-            self._init_tp_index()
-            self._update_callback_map()
-
         return self._topic_name_index
 
     async def on_partitions_assigned(self, assigned: Set[TP]) -> None:
@@ -352,6 +348,7 @@ class Conductor(ConductorT, Service):
         T(self._update_callback_map)()
 
     async def on_client_only_start(self) -> None:
+        self.log.info("Starting client only mode with %s topics...", self._topics)
         self._init_tp_index()
         self._update_callback_map()
 
@@ -420,7 +417,7 @@ class Conductor(ConductorT, Service):
 
     def _topic_contain_unsubscribed_topics(self, topic: TopicT) -> bool:
         index = self._topic_name_index
-        return bool(index and any(t not in index for t in topic.topics))
+        return bool(any(t not in index for t in topic.topics))
 
     def discard(self, topic: Any) -> None:
         """Unregister topic from conductor."""

--- a/faust/transport/conductor.py
+++ b/faust/transport/conductor.py
@@ -348,15 +348,12 @@ class Conductor(ConductorT, Service):
         T(self._update_callback_map)()
 
     async def on_client_only_start(self) -> None:
-        self._init_tp_index()
-        self._update_callback_map()
-
-    def _init_tp_index(self) -> None:
         tp_index = self._tp_index
         for topic in self._topics:
             for subtopic in topic.topics:
                 tp = TP(topic=subtopic, partition=0)
                 tp_index[tp].add(topic)
+        self._update_callback_map()
 
     def _update_tp_index(self, assigned: Set[TP]) -> None:
         assignmap = tp_set_to_map(assigned)

--- a/faust/transport/conductor.py
+++ b/faust/transport/conductor.py
@@ -338,8 +338,10 @@ class Conductor(ConductorT, Service):
                     self._acking_topics.add(topic)
                 self._topic_name_index[topic].add(channel)
 
-        self._init_tp_index()
-        self._update_callback_map()
+        if self.app.client_only:
+            self._init_tp_index()
+            self._update_callback_map()
+
         return self._topic_name_index
 
     async def on_partitions_assigned(self, assigned: Set[TP]) -> None:

--- a/faust/transport/conductor.py
+++ b/faust/transport/conductor.py
@@ -338,6 +338,8 @@ class Conductor(ConductorT, Service):
                     self._acking_topics.add(topic)
                 self._topic_name_index[topic].add(channel)
 
+        self._init_tp_index()
+        self._update_callback_map()
         return self._topic_name_index
 
     async def on_partitions_assigned(self, assigned: Set[TP]) -> None:
@@ -348,12 +350,15 @@ class Conductor(ConductorT, Service):
         T(self._update_callback_map)()
 
     async def on_client_only_start(self) -> None:
+        self._init_tp_index()
+        self._update_callback_map()
+
+    def _init_tp_index(self) -> None:
         tp_index = self._tp_index
         for topic in self._topics:
             for subtopic in topic.topics:
                 tp = TP(topic=subtopic, partition=0)
                 tp_index[tp].add(topic)
-        self._update_callback_map()
 
     def _update_tp_index(self, assigned: Set[TP]) -> None:
         assignmap = tp_set_to_map(assigned)

--- a/faust/transport/conductor.py
+++ b/faust/transport/conductor.py
@@ -348,7 +348,6 @@ class Conductor(ConductorT, Service):
         T(self._update_callback_map)()
 
     async def on_client_only_start(self) -> None:
-        self.log.info("Starting client only mode with %s topics...", self._topics)
         self._init_tp_index()
         self._update_callback_map()
 

--- a/tests/unit/agents/test_replies.py
+++ b/tests/unit/agents/test_replies.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from unittest.mock import Mock
+from unittest.mock import Mock, MagicMock
 
 import pytest
 
@@ -192,7 +192,7 @@ class Test_ReplyConsumer:
     async def test_start_fetcher(self, *, c):
         c._drain_replies = Mock()
         c._reply_topic = Mock(
-            return_value=Mock(
+            return_value=MagicMock(
                 maybe_declare=AsyncMock(),
             ),
         )

--- a/tests/unit/agents/test_replies.py
+++ b/tests/unit/agents/test_replies.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 


### PR DESCRIPTION
A startup race on adding topics to the conductor when `app.conf.reply_create_topic == True` and the app is started in client only mode: `app.start_client()` causes a lookup in the callback map in the conductor before the callbacks have been registered.

Fixes #298 

[EDIT]
Actually, I think the callbacks never get built regardless, because the side-effect of setting `_flag_changes` doesn't rebuild `_tp_index` or `_topic_name_index`, so calling `add` to add a topic after `on_client_only_start` is the issue. The application startup is a little hard to reason about, but that's my understanding.
