### PR TITLE
Fixes AttributeError: 'list' object has no attribute 'difference' in …

### DIFF
--- a/faust/tables/sets.py
+++ b/faust/tables/sets.py
@@ -245,7 +245,7 @@ class SetTableManager(Service, Generic[KT, VT]):
             except ValueError:
                 self.log.exception("Unknown set operation: %r", set_operation.action)
             else:
-                members = [_maybe_model(m) for m in set_operation.members]
+                members = {_maybe_model(m) for m in set_operation.members}
                 handler = actions[action]
                 handler(set_key, members)
 


### PR DESCRIPTION
## Description

The `SetTableManager` is falling over during updates because the `members` being added is obviously not a `set` and `mode/utils/collections.py` just does `cast(Set, ...)` which just lies to the type system

```
[2023-06-13 13:08:25,368] [222966] [ERROR] [^----Agent*: faust.tables.sets.[.]_modify_set]: Crashed reason=AttributeError("'list' object has no attribute 'difference'") 
Traceback (most recent call last):
  File "/home/richard/Work/pinktum-ai/ai-platform/.venv/lib/python3.10/site-packages/faust/agents/agent.py", line 674, in _execute_actor
    await coro
  File "/home/richard/Work/pinktum-ai/ai-platform/.venv/lib/python3.10/site-packages/faust/tables/sets.py", line 250, in _modify_set
    handler(set_key, members)
  File "/home/richard/Work/pinktum-ai/ai-platform/.venv/lib/python3.10/site-packages/faust/tables/sets.py", line 207, in _update
    self.set_table[key].update(members)
  File "/home/richard/Work/pinktum-ai/ai-platform/.venv/lib/python3.10/site-packages/mode/utils/collections.py", line 622, in update
    added=cast(Set, other).difference(self),
AttributeError: 'list' object has no attribute 'difference'
```
