### PR TITLE
Fix set operations in `ChangeloggedSet`

### DIFF
--- a/faust/tables/sets.py
+++ b/faust/tables/sets.py
@@ -245,7 +245,7 @@ class SetTableManager(Service, Generic[KT, VT]):
             except ValueError:
                 self.log.exception("Unknown set operation: %r", set_operation.action)
             else:
-                members = [_maybe_model(m) for m in set_operation.members]
+                members = {_maybe_model(m) for m in set_operation.members}
                 handler = actions[action]
                 handler(set_key, members)
 

--- a/faust/tables/sets.py
+++ b/faust/tables/sets.py
@@ -84,7 +84,7 @@ class ChangeloggedSet(ChangeloggedObject, ManagedUserSet[VT]):
         self.manager.send_changelog_event(self.key, OPERATION_UPDATE, [added, removed])
 
     def sync_from_storage(self, value: Any) -> None:
-        self.data = cast(Set, value)
+        self.data = set(value)
 
     def as_stored_value(self) -> Any:
         return self.data
@@ -204,19 +204,19 @@ class SetTableManager(Service, Generic[KT, VT]):
         await self._send_operation(SetAction.SYMDIFF, key, members)
 
     def _update(self, key: KT, members: List[VT]) -> None:
-        self.set_table[key].update(members)
+        self.set_table[key].update(set(members))
 
     def _difference_update(self, key: KT, members: List[VT]) -> None:
-        self.set_table[key].difference_update(members)
+        self.set_table[key].difference_update(set(members))
 
     def _clear(self, key: KT, members: List[VT]) -> None:
         self.set_table[key].clear()
 
     def _intersection_update(self, key: KT, members: List[VT]) -> None:
-        self.set_table[key].intersection_update(members)
+        self.set_table[key].intersection_update(set(members))
 
     def _symmetric_difference_update(self, key: KT, members: List[VT]) -> None:
-        self.set_table[key].symmetric_difference_update(members)
+        self.set_table[key].symmetric_difference_update(set(members))
 
     async def _send_operation(
         self, action: SetAction, key: KT, members: Iterable[VT]
@@ -245,7 +245,7 @@ class SetTableManager(Service, Generic[KT, VT]):
             except ValueError:
                 self.log.exception("Unknown set operation: %r", set_operation.action)
             else:
-                members = {_maybe_model(m) for m in set_operation.members}
+                members = [_maybe_model(m) for m in set_operation.members]
                 handler = actions[action]
                 handler(set_key, members)
 

--- a/tests/unit/tables/test_sets.py
+++ b/tests/unit/tables/test_sets.py
@@ -248,12 +248,12 @@ class Test_SetTableManager:
     def test__update(self, *, man):
         man.set_table = {"a": Mock(name="a"), "b": Mock(name="b")}
         man._update("a", ["v1"])
-        man.set_table["a"].update.assert_called_once_with(["v1"])
+        man.set_table["a"].update.assert_called_once_with({"v1"})
 
     def test__difference_update(self, *, man):
         man.set_table = {"a": Mock(name="a"), "b": Mock(name="b")}
         man._difference_update("a", ["v1"])
-        man.set_table["a"].difference_update.assert_called_once_with(["v1"])
+        man.set_table["a"].difference_update.assert_called_once_with({"v1"})
 
     def test__clear(self, *, man):
         man.set_table = {"a": Mock(name="a"), "b": Mock(name="b")}
@@ -264,14 +264,14 @@ class Test_SetTableManager:
         man.set_table = {"a": Mock(name="a"), "b": Mock(name="b")}
         man._intersection_update("a", ["v1", "v2", "v3"])
         man.set_table["a"].intersection_update.assert_called_once_with(
-            ["v1", "v2", "v3"],
+            {"v1", "v2", "v3"},
         )
 
     def test__symmetric_difference_update(self, *, man):
         man.set_table = {"a": Mock(name="a"), "b": Mock(name="b")}
         man._symmetric_difference_update("a", ["v1", "v2", "v3"])
         man.set_table["a"].symmetric_difference_update.assert_called_once_with(
-            ["v1", "v2", "v3"],
+            {"v1", "v2", "v3"},
         )
 
     @pytest.mark.asyncio
@@ -396,29 +396,29 @@ class Test_SetTableManager:
 
         await man._modify_set(stream)
 
-        man.set_table["k1"].update.assert_called_with(["v"])
-        man.set_table["k2"].difference_update.assert_called_with(["v2"])
-        man.set_table["k3"].difference_update.assert_called_with([X(10, 30)])
+        man.set_table["k1"].update.assert_called_with({"v"})
+        man.set_table["k2"].difference_update.assert_called_with({"v2"})
+        man.set_table["k3"].difference_update.assert_called_with({X(10, 30)})
         man.set_table["k5"].update.assert_called_with(
-            [
+            {
                 X(10, 30),
                 X(20, 40),
                 "v3",
-            ]
+            }
         )
         man.set_table["k6"].intersection_update.assert_called_with(
-            [
+            {
                 X(10, 30),
                 X(20, 40),
                 "v3",
-            ]
+            }
         )
         man.set_table["k7"].symmetric_difference_update.assert_called_with(
-            [
+            {
                 X(10, 30),
                 X(20, 40),
                 "v3",
-            ]
+            }
         )
         man.set_table["k8"].clear.assert_called_once_with()
 


### PR DESCRIPTION
## Description

Make sure that sets are recovered during `sync_from_storage` which stores a `list`, and pass actual set objects to the underlying `ManagedUserSet` from mode which is depends on actual `SetLike` objects instead of lists.