### PR TITLE
Fix periodic flush not having a `current_event` in context

### DIFF
--- a/faust/tables/objects.py
+++ b/faust/tables/objects.py
@@ -65,20 +65,18 @@ class ChangeloggedObjectManager(Store):
     data: MutableMapping
 
     _storage: Optional[StoreT] = None
-    _dirty: Set
 
     def __init__(self, table: Table, **kwargs: Any) -> None:
         self.table = table
         self.table_name = self.table.name
         self.data = {}
-        self._dirty = set()
         Service.__init__(self, loop=table.loop, **kwargs)
 
     def send_changelog_event(self, key: Any, operation: int, value: Any) -> None:
         """Send changelog event to the tables changelog topic."""
         event = current_event()
-        self._dirty.add(key)
         self.table._send_changelog(event, (operation, key), value)
+        self.storage[key] = self[key].as_stored_value()
 
     def __getitem__(self, key: Any) -> ChangeloggedObject:
         if key in self.data:
@@ -99,10 +97,6 @@ class ChangeloggedObjectManager(Store):
     async def on_start(self) -> None:
         """Call when the changelogged object manager starts."""
         await self.add_runtime_dependency(self.storage)
-
-    async def on_stop(self) -> None:
-        """Call when the changelogged object manager stops."""
-        self.flush_to_storage()
 
     def persisted_offset(self, tp: TP) -> Optional[int]:
         """Get the last persisted offset for changelog topic partition."""
@@ -132,17 +126,6 @@ class ChangeloggedObjectManager(Store):
         """Sync set contents from storage."""
         for key, value in self.storage.items():
             self[key].sync_from_storage(value)
-
-    def flush_to_storage(self) -> None:
-        """Flush set contents to storage."""
-        for key in self._dirty:
-            self.storage[key] = self.data[key].as_stored_value()
-        self._dirty.clear()
-
-    @Service.task
-    async def _periodic_flush(self) -> None:  # pragma: no cover
-        async for sleep_time in self.itertimer(2.0, name="SetManager.flush"):
-            self.flush_to_storage()
 
     def reset_state(self) -> None:
         """Reset table local state."""

--- a/tests/unit/tables/test_objects.py
+++ b/tests/unit/tables/test_objects.py
@@ -54,6 +54,7 @@ class Test_ChangeloggedObjectManager:
     def man(self, *, table):
         man = ChangeloggedObjectManager(table)
         man.ValueType = ValueType
+        man.storage.__setitem__ = Mock()
         return man
 
     @pytest.fixture()
@@ -62,7 +63,7 @@ class Test_ChangeloggedObjectManager:
 
     def test_send_changelog_event(self, *, man, table, key, current_event):
         man.send_changelog_event(key, 3, "value")
-        assert key in man._dirty
+        assert man.storage.__setitem__.called_once_with(key, "value")
         table._send_changelog.assert_called_once_with(
             current_event(),
             (3, key),
@@ -98,12 +99,6 @@ class Test_ChangeloggedObjectManager:
         await man.on_start()
         man.add_runtime_dependency.assert_called_once_with(man.storage)
 
-    @pytest.mark.asyncio
-    async def test_on_stop(self, *, man):
-        man.flush_to_storage = Mock()
-        await man.on_stop()
-        man.flush_to_storage.assert_called_once_with()
-
     def test_persisted_offset(self, *, man, storage):
         ret = man.persisted_offset(TP1)
         storage.persisted_offset.assert_called_once_with(TP1)
@@ -134,14 +129,6 @@ class Test_ChangeloggedObjectManager:
         man.sync_from_storage()
         assert 1 in man["foo"].synced
         assert 2 in man["bar"].synced
-
-    def test_flush_to_storage(self, *, man):
-        man._storage = {}
-        man._dirty = {"foo", "bar"}
-        assert man["foo"]
-        assert man["bar"]
-        man.flush_to_storage()
-        assert man._storage["foo"] == "foo-stored"
 
     def test_reset_state(self, *, man, storage):
         man.reset_state()


### PR DESCRIPTION
## Description

~~Track the partition during send_changelog_event so that the background periodic flushing task can recover it~~ Remove the periodic flush because there's no current_event in scope, and rocksdb storage needs to know.

The periodic flush doesn't seem to add any value since any disk I/O will still be synchronous even if running in a separate coroutine.
