### PR TITLE
Implement OAuthbearer auth mechanism

### DIFF
--- a/docs/includes/settingref.txt
+++ b/docs/includes/settingref.txt
@@ -439,6 +439,41 @@ SASL Authentication
                    password=BROKER_PASSWORD,
                ))
 
+OAuth2 Authentication
+   You can enable SASL authentication via OAuth2 Bearer tokens:
+
+   .. sourcecode:: python
+
+       import faust
+       from asyncio import get_running_loop
+       from aiokafka.helpers import create_ssl_context
+       from aiokafka.conn import AbstractTokenProvider
+
+       class TokenProvider(AbstractTokenProvider):
+           async def token(self):
+               return await get_running_loop().run_in_executor(
+                   None, self.get_token)
+
+           def get_token(self):
+               return 'token'
+
+        app = faust.App(
+            broker_credentials=faust.OAuthCredentials(
+                oauth_cb=TokenProvider()
+                ssl_context=create_ssl_context()
+            )
+        )
+
+    .. info::
+
+        The implementation should ensure token reuse so that multiple
+        calls at connect time do not create multiple tokens.
+        The implementation should also periodically refresh the token in order to
+        guarantee that each call returns an unexpired token.
+
+        Token Providers MUST implement the :meth:`token` method
+
+
 GSSAPI Authentication
    GSSAPI authentication over plain text:
 

--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -133,7 +133,12 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
     from .agents import Agent  # noqa: E402
     from .app import App  # noqa: E402
-    from .auth import GSSAPICredentials, SASLCredentials, SSLCredentials  # noqa: E402
+    from .auth import (
+        GSSAPICredentials,
+        SASLCredentials,
+        SSLCredentials,
+        OAuthCredentials,
+    )  # noqa: E402
     from .channels import Channel, ChannelT  # noqa: E402
     from .events import Event, EventT  # noqa: E402
     from .models import Model, ModelOptions, Record  # noqa: E402
@@ -184,6 +189,7 @@ __all__ = [
     "TopicT",
     "GSSAPICredentials",
     "SASLCredentials",
+    "OAuthCredentials",
     "SSLCredentials",
     "Settings",
     "HoppingWindow",
@@ -219,6 +225,7 @@ all_by_module: Mapping[str, Sequence[str]] = {
         "GSSAPICredentials",
         "SASLCredentials",
         "SSLCredentials",
+        "OAuthCredentials",
     ],
     "faust.types.settings": ["Settings"],
     "faust.windows": [

--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -133,12 +133,12 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
     from .agents import Agent  # noqa: E402
     from .app import App  # noqa: E402
-    from .auth import (
+    from .auth import (  # noqa: E402
         GSSAPICredentials,
+        OAuthCredentials,
         SASLCredentials,
         SSLCredentials,
-        OAuthCredentials,
-    )  # noqa: E402
+    )
     from .channels import Channel, ChannelT  # noqa: E402
     from .events import Event, EventT  # noqa: E402
     from .models import Model, ModelOptions, Record  # noqa: E402

--- a/faust/auth.py
+++ b/faust/auth.py
@@ -9,6 +9,7 @@ from faust.types.auth import AuthProtocol, CredentialsT, SASLMechanism
 __all__ = [
     "Credentials",
     "SASLCredentials",
+    "OAuthCredentials",
     "GSSAPICredentials",
     "SSLCredentials",
 ]

--- a/faust/auth.py
+++ b/faust/auth.py
@@ -1,6 +1,6 @@
 """Authentication Credentials."""
 import ssl
-from typing import Any, Optional, Union, Tuple, Callable
+from typing import Any, Callable, Optional, Tuple, Union
 
 from faust.types.auth import AuthProtocol, CredentialsT, SASLMechanism
 

--- a/faust/auth.py
+++ b/faust/auth.py
@@ -53,11 +53,7 @@ class SASLCredentials(Credentials):
 
 
 class OAuthCredentials(Credentials):
-    """Describe OAuth Bearer credentials over SASL
-
-    The `oauth_cb` callback must implement an asynchronous method called
-    `token()`. See the AbstractTokenProvider metaclass for more details.
-    """
+    """Describe OAuth Bearer credentials over SASL"""
 
     protocol = AuthProtocol.SASL_PLAINTEXT
     mechanism: SASLMechanism = SASLMechanism.OAUTHBEARER

--- a/faust/auth.py
+++ b/faust/auth.py
@@ -2,6 +2,8 @@
 import ssl
 from typing import Any, Callable, Optional, Tuple, Union
 
+from aiokafka.conn import AbstractTokenProvider
+
 from faust.types.auth import AuthProtocol, CredentialsT, SASLMechanism
 
 __all__ = [
@@ -50,7 +52,11 @@ class SASLCredentials(Credentials):
 
 
 class OAuthCredentials(Credentials):
-    """Describe OAuth Bearer credentials over SASL"""
+    """Describe OAuth Bearer credentials over SASL
+
+    The `oauth_cb` callback must implement an asynchronous method called
+    `token()`. See the AbstractTokenProvider metaclass for more details.
+    """
 
     protocol = AuthProtocol.SASL_PLAINTEXT
     mechanism: SASLMechanism = SASLMechanism.OAUTHBEARER
@@ -61,7 +67,7 @@ class OAuthCredentials(Credentials):
         self,
         *,
         client_id: str,
-        oauth_cb: Callable[[str], Tuple[str, ...]],
+        oauth_cb: AbstractTokenProvider,
         ssl_context: Optional[ssl.SSLContext] = None,
     ):
         self.client_id = client_id

--- a/faust/auth.py
+++ b/faust/auth.py
@@ -1,6 +1,6 @@
 """Authentication Credentials."""
 import ssl
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from aiokafka.conn import AbstractTokenProvider
 

--- a/faust/auth.py
+++ b/faust/auth.py
@@ -63,11 +63,9 @@ class OAuthCredentials(Credentials):
     def __init__(
         self,
         *,
-        client_id: str,
         oauth_cb: AbstractTokenProvider,
         ssl_context: Optional[ssl.SSLContext] = None,
     ):
-        self.client_id = client_id
         self.oauth_cb = oauth_cb
         self.ssl_context = ssl_context
 
@@ -75,7 +73,10 @@ class OAuthCredentials(Credentials):
             self.protocol = AuthProtocol.SASL_SSL
 
     def __repr__(self) -> str:
-        return f"<{type(self).__name__}: client.id={self.client_id}"
+        return "<{0}: oauth credentials {1} SSL support".format(
+            type(self).__name__,
+            "with" if self.protocol == AuthProtocol.SASL_SSL else "without",
+        )
 
 
 class GSSAPICredentials(Credentials):

--- a/faust/auth.py
+++ b/faust/auth.py
@@ -1,6 +1,6 @@
 """Authentication Credentials."""
 import ssl
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, Tuple, Callable
 
 from faust.types.auth import AuthProtocol, CredentialsT, SASLMechanism
 
@@ -47,6 +47,31 @@ class SASLCredentials(Credentials):
 
     def __repr__(self) -> str:
         return f"<{type(self).__name__}: username={self.username}>"
+
+
+class OAuthCredentials(Credentials):
+    """Describe OAuth Bearer credentials over SASL"""
+
+    protocol = AuthProtocol.SASL_PLAINTEXT
+    mechanism: SASLMechanism = SASLMechanism.OAUTHBEARER
+
+    ssl_context: Optional[ssl.SSLContext]
+
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        oauth_cb: Callable[[str], Tuple[str, ...]],
+        ssl_context: Optional[ssl.SSLContext] = None,
+    ):
+        self.client_id = client_id
+        self.oauth_cb = oauth_cb
+
+        if ssl_context is not None:
+            self.ssl_context = ssl_context
+
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__}: client.id={self.client_id}"
 
 
 class GSSAPICredentials(Credentials):

--- a/faust/auth.py
+++ b/faust/auth.py
@@ -69,9 +69,10 @@ class OAuthCredentials(Credentials):
     ):
         self.client_id = client_id
         self.oauth_cb = oauth_cb
+        self.ssl_context = ssl_context
 
         if ssl_context is not None:
-            self.ssl_context = ssl_context
+            self.protocol = AuthProtocol.SASL_SSL
 
     def __repr__(self) -> str:
         return f"<{type(self).__name__}: client.id={self.client_id}"

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -55,7 +55,12 @@ from mode.utils.typing import Deque
 from opentracing.ext import tags
 from yarl import URL
 
-from faust.auth import GSSAPICredentials, SASLCredentials, SSLCredentials, OAuthCredentials
+from faust.auth import (
+    GSSAPICredentials,
+    OAuthCredentials,
+    SASLCredentials,
+    SSLCredentials,
+)
 from faust.exceptions import (
     ConsumerNotStarted,
     ImproperlyConfigured,

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -55,7 +55,7 @@ from mode.utils.typing import Deque
 from opentracing.ext import tags
 from yarl import URL
 
-from faust.auth import GSSAPICredentials, SASLCredentials, SSLCredentials
+from faust.auth import GSSAPICredentials, SASLCredentials, SSLCredentials, OAuthCredentials
 from faust.exceptions import (
     ConsumerNotStarted,
     ImproperlyConfigured,
@@ -1583,6 +1583,13 @@ def credentials_to_aiokafka_auth(
             return {
                 "security_protocol": credentials.protocol.value,
                 "ssl_context": credentials.context,
+            }
+        elif isinstance(credentials, OAuthCredentials):
+            return {
+                "security_protocol": credentials.protocol.value,
+                "sasl_mechanism": credentials.mechanism.value,
+                "sasl_oauth_token_provider": credentials.oauth_cb,
+                "ssl_context": credentials.ssl_context,
             }
         elif isinstance(credentials, SASLCredentials):
             return {

--- a/faust/types/auth.py
+++ b/faust/types/auth.py
@@ -25,6 +25,7 @@ class SASLMechanism(Enum):
     GSSAPI = "GSSAPI"
     SCRAM_SHA_256 = "SCRAM-SHA-256"
     SCRAM_SHA_512 = "SCRAM-SHA-512"
+    OAUTHBEARER = "OAUTHBEARER"
 
 
 AUTH_PROTOCOLS_SSL = {AuthProtocol.SSL, AuthProtocol.SASL_SSL}

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,15 +1,15 @@
-import ssl
 import asyncio
+import ssl
 from unittest.mock import Mock, patch
 
 import pytest
-
 from aiokafka.conn import AbstractTokenProvider
+
 from faust.auth import (
     GSSAPICredentials,
+    OAuthCredentials,
     SASLCredentials,
     SSLCredentials,
-    OAuthCredentials,
 )
 from faust.types.auth import AuthProtocol, SASLMechanism
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -162,7 +162,7 @@ class Test_OAuthCredentials:
         [
             pytest.param(
                 "retains arguments",
-                OAuthCredentials(client_id="test", oauth_cb=TokenProvider()),
+                OAuthCredentials(oauth_cb=TokenProvider()),
                 {
                     "mechanism": SASLMechanism.OAUTHBEARER,
                     "protocol": AuthProtocol.SASL_PLAINTEXT,
@@ -171,7 +171,6 @@ class Test_OAuthCredentials:
             pytest.param(
                 "retains arguments",
                 OAuthCredentials(
-                    client_id="test",
                     oauth_cb=TokenProvider(),
                     ssl_context={"xxx": "yyy"},
                 ),

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -168,6 +168,18 @@ class Test_OAuthCredentials:
                     "protocol": AuthProtocol.SASL_PLAINTEXT,
                 },
             ),
+            pytest.param(
+                "retains arguments",
+                OAuthCredentials(
+                    client_id="test",
+                    oauth_cb=TokenProvider(),
+                    ssl_context={"xxx": "yyy"},
+                ),
+                {
+                    "mechanism": SASLMechanism.OAUTHBEARER,
+                    "protocol": AuthProtocol.SASL_SSL,
+                },
+            ),
         ],
     )
     def test_constructor(self, credentials, expected_fields, reason):

--- a/tests/unit/transport/drivers/test_aiokafka.py
+++ b/tests/unit/transport/drivers/test_aiokafka.py
@@ -1992,6 +1992,16 @@ class TestTransport:
                 "ssl_context": None,
             },
         ),
+        (
+            auth.OAuthCredentials(oauth_cb="token"),
+            None,
+            {
+                "security_protocol": "SASL_PLAINTEXT",
+                "sasl_oauth_token_provider": "token",
+                "sasl_mechanism": "OAUTHBEARER",
+                "ssl_context": None,
+            },
+        ),
     ],
 )
 def test_credentials_to_aiokafka(credentials, ssl_context, expected):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust-streaming.github.io/faust/contributing.html).

## Description

This PR adds an `OAuthCredentials` class to facilitate the OAuth2 SASL mechanism for producers/consumers. I was able to test this by creating an instance of aiokafka's `AbstractTokenProvider` and generating a token from my IdP inside a Faust worker 

Addresses #519 