### PR TITLE
Add username field from URL connection string

### DIFF
--- a/faust/web/cache/backends/redis.py
+++ b/faust/web/cache/backends/redis.py
@@ -140,6 +140,7 @@ class CacheBackend(base.CacheBackend):
                 host=url.host,
                 port=url.port,
                 db=self._db_from_path(url.path),
+                username=url.user,
                 password=url.password,
                 connect_timeout=self._float_from_str(
                     connect_timeout, self.connect_timeout


### PR DESCRIPTION
## Description

If a user is specified in the connection string to the radish, then the system crashes with an error.

cache='redis://username:password@localhost:6379

Not working.

This fix bug, which related with https://github.com/NoneGG/aredis/issues/223
