### PR TITLE
fix: docs Autodetect for schemas

### DIFF
--- a/docs/userguide/models.rst
+++ b/docs/userguide/models.rst
@@ -186,13 +186,13 @@ a schema that reads message key and value type from Kafka headers:
                         serializer=None):
             if loads is None:
                 loads = app.serializers.loads_value
-            # try to get key_type and serializer from Kafka headers
+            # try to get value_type and serializer from Kafka headers
             headers = dict(message.headers)
             value_type_name = headers.get('ValueType')
             serializer = serializer or headers.get('ValueSerializer')
             if value_type_name:
-                value_type = registry[value_type]
-                return loads(value_type, message.key,
+                value_type = registry[value_type_name]
+                return loads(value_type, message.value,
                        serializer=serializer)
             else:
                 return super().loads_value(


### PR DESCRIPTION
(Fixes [#560](https://github.com/faust-streaming/faust/issues/560))

## Description
I noticed a discrepancy in the documentation, specifically in the example for the Autodetect class. Here are the details of the issue I fixed:

In the documentation example, the variable value_type was not defined before being referenced in the following lines of code:
```python
value_type = registry[value_type]   # <-- value_type is not defined
return loads(value_type, message.key, serializer=serializer)  # <-- maybe message.value?
```
It appears that there might have been a typo or misunderstanding, and it should have been `value_type_name` instead of `value_type`.

Additionally, I noticed a comment in the code that seemed to be a victim of a copy-paste error. It read: `try to get key_type and serializer from Kafka headers,` which I believe should have been: `try to get value_type and serializer from Kafka headers.`

I fixed the issue by making the necessary changes, and I also raised questions about whether it is intended to pass `message.key` in the last line, and if `message.value` should be considered instead.

