### PR TITLE
Fix potential NoneType access in aiokafka driver

### DIFF
--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -836,7 +836,7 @@ class AIOKafkaConsumerThread(ConsumerThread):
         secs_since_started = now - self.time_started
         aiotp = TopicPartition(tp.topic, tp.partition)
         assignment = consumer._fetcher._subscriptions.subscription.assignment
-        if not assignment and not assignment.active:
+        if not assignment or not assignment.active:
             self.log.error(f"No active partitions for {tp}")
             return True
         poll_at = None


### PR DESCRIPTION
## Description

This logic is likely meant to be a boolean `OR` not `AND`, since the first check in the statement checks for `assignment` to be `None`.