### PR TITLE
Consolidate dynamic attributes for setuptools v69.0.0 and move some metadata definitions into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,73 @@
 [project]
 name = "faust-streaming"
 requires-python = ">=3.8"
-dynamic = ["version"]
+dynamic = [
+    "version",
+    "optional-dependencies",
+    "dependencies",
+
+]
+readme = "README.md"
+license = { file = "LICENSE" }
+keywords = [
+    "stream",
+    "processing",
+    "asyncio",
+    "distributed",
+    "queue",
+    "kafka",
+]
+classifiers = [
+    "Framework :: AsyncIO",
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Operating System :: POSIX",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: POSIX :: BSD",
+    "Operating System :: Microsoft :: Windows",
+    "Topic :: System :: Networking",
+    "Topic :: System :: Distributed Computing",
+]
+
+authors = [
+    "Ask Solem Hoel",
+]
+
+maintainers = [
+    "William Barnhart <williambbarnhart@gmail.com>",
+    "Vikram Patki",
+]
+
+[project.urls]
+Documentation = "https://faust-streaming.github.io/faust/"
+Source = "https://github.com/faust-streaming/faust"
+Changes = "https://github.com/faust-streaming/faust/releases"
 
 [build-system]
 requires = [
-    "setuptools>=30.3.0,<69.0.0",
+    "setuptools>=30.3.0",
     "setuptools_scm[toml]",
     "wheel",
     "cython>=0.29; implementation_name == 'cpython'",
-    "cython>=3.0.0b3; implementation_name == 'cpython' and python_version >= '3.12'",
+    "cython>=3.0.0; implementation_name == 'cpython' and python_version >= '3.12'",
 ]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 # enables setuptools_scm to provide the dynamic version
+
+[tool.setuptools.dynamic]
+version = { attr = "faust.__version__" }
 
 [tool.flake8]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,12 @@ classifiers = [
 ]
 
 authors = [
-    "Ask Solem Hoel",
+#    "Ask Solem Hoel",
 ]
 
 maintainers = [
-    "William Barnhart <williambbarnhart@gmail.com>",
-    "Vikram Patki",
+#    "William Barnhart <williambbarnhart@gmail.com>",
+#    "Vikram Patki",
 ]
 
 [project.urls]
@@ -65,9 +65,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 # enables setuptools_scm to provide the dynamic version
-
-[tool.setuptools.dynamic]
-version = { attr = "faust.__version__" }
 
 [tool.flake8]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,13 +40,15 @@ classifiers = [
 ]
 
 authors = [
-#    "Ask Solem Hoel",
+    { name = "Ask Solem Hoel", email= "ask@robinhood.com" },
+    { name = "Vineet Goel", email= "vineet@robinhood.com" },
 ]
 
 maintainers = [
-#    "William Barnhart <williambbarnhart@gmail.com>",
-#    "Vikram Patki",
+    { name = "Vikram Patki", email = "vpatki@wayfair.com" },
+    { name = "William Barnhart", email = "williambbarnhart@gmail.com" },
 ]
+
 
 [project.urls]
 Documentation = "https://faust-streaming.github.io/faust/"

--- a/setup.py
+++ b/setup.py
@@ -181,23 +181,12 @@ def extras_require():
     return {x: extras(x + ".txt") for x in BUNDLES}
 
 
-with open("README.md") as readme_file:
-    long_description = readme_file.read()
-
 
 def do_setup(**kwargs):
     setup(
         name="faust-streaming",
-        use_scm_version=True,
-        setup_requires=["setuptools_scm"],
         description=meta["doc"],
-        long_description=long_description,
         long_description_content_type="text/markdown",
-        author=meta["author"],
-        author_email=meta["contact"],
-        url=meta["homepage"],
-        platforms=["any"],
-        license="BSD 3-Clause",
         packages=find_packages(exclude=["examples", "ez_setup", "tests", "tests.*"]),
         # PEP-561: https://www.python.org/dev/peps/pep-0561/
         package_data={"faust": ["py.typed"]},
@@ -212,40 +201,6 @@ def do_setup(**kwargs):
                 "faust = faust.cli.faust:cli",
             ],
         },
-        project_urls={
-            "Bug Reports": "https://github.com/faust-streaming/faust/issues",
-            "Source": "https://github.com/faust-streaming/faust",
-            "Documentation": "https://faust-streaming.github.io/faust",
-        },
-        keywords=[
-            "stream",
-            "processing",
-            "asyncio",
-            "distributed",
-            "queue",
-            "kafka",
-        ],
-        classifiers=[
-            "Framework :: AsyncIO",
-            "Development Status :: 5 - Production/Stable",
-            "Intended Audience :: Developers",
-            "Natural Language :: English",
-            "License :: OSI Approved :: BSD License",
-            "Programming Language :: Python",
-            "Programming Language :: Python :: 3 :: Only",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: 3.11",
-            "Programming Language :: Python :: Implementation :: CPython",
-            "Operating System :: POSIX",
-            "Operating System :: POSIX :: Linux",
-            "Operating System :: MacOS :: MacOS X",
-            "Operating System :: POSIX :: BSD",
-            "Operating System :: Microsoft :: Windows",
-            "Topic :: System :: Networking",
-            "Topic :: System :: Distributed Computing",
-        ],
         **kwargs,
     )
 

--- a/setup.py
+++ b/setup.py
@@ -181,10 +181,15 @@ def extras_require():
     return {x: extras(x + ".txt") for x in BUNDLES}
 
 
+with open("README.md") as readme_file:
+    long_description = readme_file.read()
+
+
 def do_setup(**kwargs):
     setup(
         name="faust-streaming",
         description=meta["doc"],
+        long_description=long_description,
         long_description_content_type="text/markdown",
         packages=find_packages(exclude=["examples", "ez_setup", "tests", "tests.*"]),
         # PEP-561: https://www.python.org/dev/peps/pep-0561/

--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,6 @@ def extras_require():
 
 def do_setup(**kwargs):
     setup(
-        name="faust-streaming",
         description=meta["doc"],
         long_description_content_type="text/markdown",
         packages=find_packages(exclude=["examples", "ez_setup", "tests", "tests.*"]),

--- a/setup.py
+++ b/setup.py
@@ -183,6 +183,7 @@ def extras_require():
 
 def do_setup(**kwargs):
     setup(
+        name="faust-streaming",
         description=meta["doc"],
         long_description_content_type="text/markdown",
         packages=find_packages(exclude=["examples", "ez_setup", "tests", "tests.*"]),

--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,6 @@ def extras_require():
     return {x: extras(x + ".txt") for x in BUNDLES}
 
 
-
 def do_setup(**kwargs):
     setup(
         name="faust-streaming",


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust-streaming.github.io/faust/contributing.html).

## Description
Will eliminate need for pinning `setuptools<69.0.0` for non-wheel builds.
