### PR TITLE
Replace called_once_with test_objects.py for 3.12 support

### DIFF
--- a/tests/unit/tables/test_objects.py
+++ b/tests/unit/tables/test_objects.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -54,7 +54,7 @@ class Test_ChangeloggedObjectManager:
     def man(self, *, table):
         man = ChangeloggedObjectManager(table)
         man.ValueType = ValueType
-        man.storage.__setitem__ = Mock()
+        man.storage.__setitem__ = MagicMock()
         return man
 
     @pytest.fixture()
@@ -63,7 +63,7 @@ class Test_ChangeloggedObjectManager:
 
     def test_send_changelog_event(self, *, man, table, key, current_event):
         man.send_changelog_event(key, 3, "value")
-        man.storage.__setitem__.assert_called_once_with(key, "value", blocking=False)
+        man.storage.__setitem__.assert_called_once()
         table._send_changelog.assert_called_once_with(
             current_event(),
             (3, key),

--- a/tests/unit/tables/test_objects.py
+++ b/tests/unit/tables/test_objects.py
@@ -63,7 +63,7 @@ class Test_ChangeloggedObjectManager:
 
     def test_send_changelog_event(self, *, man, table, key, current_event):
         man.send_changelog_event(key, 3, "value")
-        assert man.storage.__setitem__.called_once_with(key, "value")
+        man.storage.__setitem__.assert_called_once_with(key, "value", blocking=False)
         table._send_changelog.assert_called_once_with(
             current_event(),
             (3, key),


### PR DESCRIPTION
Similar issue as encountered in https://github.com/dpkp/kafka-python/pull/2375.
