### PR TITLE
enable kafka static-partition-assignment (KIP-345)

### DIFF
--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -525,7 +525,7 @@ class AIOKafkaConsumerThread(ConsumerThread):
             api_version=conf.consumer_api_version,
             client_id=conf.broker_client_id,
             group_id=conf.id,
-            # group_instance_id=conf.consumer_group_instance_id,
+            group_instance_id=conf.consumer_group_instance_id,
             bootstrap_servers=server_list(transport.url, transport.default_port),
             partition_assignment_strategy=[self._assignor],
             enable_auto_commit=False,

--- a/tests/unit/transport/drivers/test_aiokafka.py
+++ b/tests/unit/transport/drivers/test_aiokafka.py
@@ -787,7 +787,7 @@ class Test_AIOKafkaConsumerThread(AIOKafkaConsumerThreadFixtures):
                 api_version=app.conf.consumer_api_version,
                 client_id=conf.broker_client_id,
                 group_id=conf.id,
-                # group_instance_id=conf.consumer_group_instance_id,
+                group_instance_id=conf.consumer_group_instance_id,
                 bootstrap_servers=server_list(transport.url, transport.default_port),
                 partition_assignment_strategy=[cthread._assignor],
                 enable_auto_commit=False,


### PR DESCRIPTION
With version v0.10.0 aiokafka implemented and tested KIP-345 (static partition assignment, PR ->https://github.com/aio-libs/aiokafka/pull/941 ).

 With this change the class `aiokafka.AIOKafkaConsumer()` accepts the `group_instance_Id` parameter.