### PR TITLE
fix: serialize (named)tuple when using orjson

### DIFF
--- a/faust/utils/json.py
+++ b/faust/utils/json.py
@@ -69,7 +69,7 @@ except ImportError:  # pragma: no cover
 DECIMAL_MAXLEN = 1000
 
 #: Types that we convert to lists.
-SEQUENCE_TYPES: TypeTuple[Iterable] = (set, frozenset, deque)
+SEQUENCE_TYPES: TypeTuple[Iterable] = (set, frozenset, deque, tuple)
 
 DateTypeTuple = Tuple[Union[Type[datetime.date], Type[datetime.time]], ...]
 DatetimeTypeTuple = Tuple[


### PR DESCRIPTION
## Description

When using `orjson`, namedtuples are not serialized. For example:
```python
>>> import faust.utils.json, orjson, inspect, aiokafka.structs
>>> print(inspect.getsource(aiokafka.structs.TopicPartition))
class TopicPartition(NamedTuple):
    """A topic and partition tuple"""

    topic: str
    "A topic name"

    partition: int
    "A partition id"

>>> tp = aiokafka.structs.TopicPartition(topic='test', partition=0)
>>> orjson.dumps(tp)
# Traceback (most recent call last):
#   File "<stdin>", line 1, in <module>
# TypeError: Type is not JSON serializable: TopicPartition
>>> faust.utils.json.dumps(tp)
# TypeError: JSON cannot serialize 'TopicPartition': TopicPartition(topic='test', partition=0)
# 
# The above exception was the direct cause of the following exception:
# 
# Traceback (most recent call last):
#   File "<stdin>", line 1, in <module>
#   File "/code/oss/github/faust-streaming/faust/faust/utils/json.py", line 176, in dumps
#     return json_dumps(
#            ^^^^^^^^^^^
# TypeError: Type is not JSON serializable: TopicPartition
```

```python
>>> # With this patch applied
>>> import faust.utils.json, orjson, inspect, aiokafka.structs
>>> tp = aiokafka.structs.TopicPartition(topic='test', partition=0)
>>> orjson.dumps(tp)
# Traceback (most recent call last):
#   File "<stdin>", line 1, in <module>
# TypeError: Type is not JSON serializable: TopicPartition
>>> faust.utils.json.dumps(tp)
b'["test",0]'
```

<details><summary>Original traceback encountered in the [page_views example](https://faust-streaming.github.io/faust/playbooks/pageviews.html) when testing within an application we're integrating faust with</summary>

```log
> faust -A faust_test send page_views '{"id": "foo", "user": "bar"}'                                                                                         
[2024-02-29 10:48:32,390] [20569] [ERROR] [^Worker]: Error: TypeError('Type is not JSON serializable: TopicPartition') 
TypeError: JSON cannot serialize 'TopicPartition': TopicPartition(topic='page_views', partition=0)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/mode/worker.py", line 279, in execute_from_commandline
    self.loop.run_until_complete(self._starting_fut)
  File "/opt/tooling/pyenv/versions/3.11.7/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/mode/services.py", line 800, in start
    await self._default_start()
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/mode/services.py", line 807, in _default_start
    await self._actually_start()
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/mode/services.py", line 831, in _actually_start
    await child.maybe_start()
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/mode/services.py", line 859, in maybe_start
    await self.start()
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/mode/services.py", line 800, in start
    await self._default_start()
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/mode/services.py", line 807, in _default_start
    await self._actually_start()
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/mode/services.py", line 824, in _actually_start
    await self.on_start()
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/mode/services.py", line 1134, in on_start
    await self._fut
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/faust/cli/base.py", line 607, in execute
    await self.run(*args, **kwargs)
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/faust/cli/send.py", line 84, in run
    self.say(self.dumps(meta._asdict()))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/faust/cli/base.py", line 746, in dumps
    return json.dumps(obj)
           ^^^^^^^^^^^^^^^
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/faust/utils/json.py", line 176, in dumps
    return json_dumps(
           ^^^^^^^^^^^
TypeError: Type is not JSON serializable: TopicPartition
[2024-02-29 10:48:32,392] [20569] [ERROR] [^Worker]: Error while stopping child <send: stopping >: TypeError('Type is not JSON serializable: TopicPartition') 
TypeError: JSON cannot serialize 'TopicPartition': TopicPartition(topic='page_views', partition=0)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/mode/services.py", line 927, in _default_stop_children
    await asyncio.shield(child.stop())
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/mode/services.py", line 902, in stop
    await self.on_stop()
  File "/opt/tooling/pyenv/versions/3.11.7/envs/hula-env/lib/python3.11/site-packages/mode/services.py", line 1145, in on_stop
    fut.result()
TypeError: Type is not JSON serializable: TopicPartition
```
</details> 

The reason for this is that unlike stdlib `json`, `orjson` does not serialize named tuples by default, so we're add the tuple baseclass to the list of sequence types that `faust.utils.json.on_default` should serialize.