### PR TITLE
Fix prometheus registry

### DIFF
--- a/faust/sensors/prometheus.py
+++ b/faust/sensors/prometheus.py
@@ -73,7 +73,7 @@ def setup_prometheus_sensors(
 
         return cast(
             _web.Response,
-            Response(body=generate_latest(REGISTRY), headers=headers, status=200),
+            Response(body=generate_latest(registry), headers=headers, status=200),
         )
 
 

--- a/faust/sensors/prometheus.py
+++ b/faust/sensors/prometheus.py
@@ -5,7 +5,7 @@ from typing import Any, NamedTuple, Optional, cast
 
 from aiohttp.web import Response
 
-from faust import web, web as _web
+from faust import web
 from faust.exceptions import ImproperlyConfigured
 from faust.types import (
     TP,
@@ -68,11 +68,11 @@ def setup_prometheus_sensors(
     app.monitor = PrometheusMonitor(metrics=faust_metrics)
 
     @app.page(pattern)
-    async def metrics_handler(self: _web.View, request: _web.Request) -> _web.Response:
+    async def metrics_handler(self: web.View, request: web.Request) -> web.Response:
         headers = {"Content-Type": CONTENT_TYPE_LATEST}
 
         return cast(
-            _web.Response,
+            web.Response,
             Response(body=generate_latest(registry), headers=headers, status=200),
         )
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust-streaming.github.io/faust/contributing.html).

## Description

The `setup_prometheus_sensors` function accepts `registry` parameter with default set to default prometheus registry. The web view to render metrics explicitly uses prometheus default registry. If anyone uses non-default registry in call to `setup_prometheus_sensors` the metrics will not be available through web view.