### PR TITLE
Add override_logging argument to Worker (#634)

### DIFF
--- a/docs/includes/settingref.txt
+++ b/docs/includes/settingref.txt
@@ -2135,6 +2135,21 @@ Level used when redirecting standard outputs.
 The logging level to use when redirect STDOUT/STDERR to logging.
 
 
+.. setting:: worker_override_logging
+
+``worker_override_logging``
+---------------------------
+
+:type: :class:`bool`
+:default: :const:`True`
+:environment: :envvar:`WORKER_OVERRIDE_LOGGING`
+
+Override worker logging.
+
+Enable to configure root logger.
+
+Enabled by default.
+
 
 .. _settings-extending:
 

--- a/faust/cli/base.py
+++ b/faust/cli/base.py
@@ -516,6 +516,7 @@ class Command(abc.ABC):  # noqa: B024
     daemon: bool = False
     redirect_stdouts: Optional[bool] = None
     redirect_stdouts_level: Optional[int] = None
+    override_logging: Optional[bool] = None
 
     builtin_options: OptionSequence = builtin_options
     options: Optional[OptionList] = None
@@ -660,6 +661,7 @@ class Command(abc.ABC):  # noqa: B024
             console_port=self.console_port,
             redirect_stdouts=self.redirect_stdouts or False,
             redirect_stdouts_level=self.redirect_stdouts_level,
+            override_logging=self.override_logging or False,
             loop=loop or asyncio.get_event_loop_policy().get_event_loop(),
             daemon=self.daemon,
         )

--- a/faust/types/settings/settings.py
+++ b/faust/types/settings/settings.py
@@ -168,6 +168,7 @@ class Settings(base.SettingsRegistry):
         # Worker settings:
         worker_redirect_stdouts: Optional[bool] = None,
         worker_redirect_stdouts_level: Severity = None,
+        worker_override_logging: Optional[bool] = None,
         # Extension settings:
         Agent: SymbolArg[Type[AgentT]] = None,
         ConsumerScheduler: SymbolArg[Type[SchedulingStrategyT]] = None,
@@ -2021,6 +2022,19 @@ class Settings(base.SettingsRegistry):
         """Level used when redirecting standard outputs.
 
         The logging level to use when redirect STDOUT/STDERR to logging.
+        """
+
+    @sections.Worker.setting(
+        params.Bool,
+        env_name="WORKER_OVERRIDE_LOGGING",
+        default=True,
+    )
+    def worker_override_logging(self) -> bool:
+        """Override worker logging.
+
+        Enable to configure root logger.
+
+        Enabled by default.
         """
 
     @sections.Extension.setting(

--- a/faust/worker.py
+++ b/faust/worker.py
@@ -229,6 +229,7 @@ class Worker(mode.Worker):
         loop: Optional[asyncio.AbstractEventLoop] = None,
         redirect_stdouts: Optional[bool] = None,
         redirect_stdouts_level: Optional[Severity] = None,
+        override_logging: Optional[bool] = None,
         logging_config: Optional[Dict] = None,
         **kwargs: Any,
     ) -> None:
@@ -240,6 +241,8 @@ class Worker(mode.Worker):
             redirect_stdouts = conf.worker_redirect_stdouts
         if redirect_stdouts_level is None:
             redirect_stdouts_level = conf.worker_redirect_stdouts_level or logging.INFO
+        if override_logging is None:
+            override_logging = conf.worker_override_logging
         if logging_config is None and app.conf.logging_config:
             logging_config = dict(app.conf.logging_config)
         super().__init__(
@@ -255,6 +258,7 @@ class Worker(mode.Worker):
             console_port=console_port,
             redirect_stdouts=redirect_stdouts,
             redirect_stdouts_level=redirect_stdouts_level,
+            override_logging=override_logging,
             logging_config=logging_config,
             loop=loop,
             **kwargs,

--- a/tests/functional/test_app.py
+++ b/tests/functional/test_app.py
@@ -444,6 +444,11 @@ class Test_settings:
                 setting=Settings.worker_redirect_stdouts_level,
                 expected_value="error",
             ),
+            EnvCase(
+                env={"WORKER_OVERRIDE_LOGGING": "no"},
+                setting=Settings.worker_override_logging,
+                expected_value=False,
+            ),
         ],
     )
     def test_env(self, env, setting, expected_value):
@@ -555,6 +560,7 @@ class Test_settings:
         assert conf.web_cors_options is None
         assert conf.worker_redirect_stdouts
         assert conf.worker_redirect_stdouts_level == "WARN"
+        assert conf.worker_override_logging
 
         assert conf.agent_supervisor is mode.OneForOneSupervisor
 
@@ -677,6 +683,7 @@ class Test_settings:
         },
         worker_redirect_stdouts=False,
         worker_redirect_stdouts_level="DEBUG",
+        worker_override_logging=False,
         broker_max_poll_records=1000,
         broker_max_poll_interval=10000,
         timezone=pytz.timezone("US/Eastern"),  # noqa: B008
@@ -745,6 +752,7 @@ class Test_settings:
             web_cors_options=web_cors_options,
             worker_redirect_stdouts=worker_redirect_stdouts,
             worker_redirect_stdouts_level=worker_redirect_stdouts_level,
+            worker_override_logging=worker_override_logging,
             logging_config=logging_config,
             consumer_auto_offset_reset=consumer_auto_offset_reset,
             ConsumerScheduler=ConsumerScheduler,
@@ -809,6 +817,7 @@ class Test_settings:
         assert conf.web_cors_options == web_cors_options
         assert conf.worker_redirect_stdouts == worker_redirect_stdouts
         assert conf.worker_redirect_stdouts_level == worker_redirect_stdouts_level
+        assert conf.worker_override_logging == worker_override_logging
         assert conf.broker_max_poll_records == broker_max_poll_records
         assert conf.broker_max_poll_interval == broker_max_poll_interval
         assert conf.logging_config == logging_config

--- a/tests/unit/cli/test_base.py
+++ b/tests/unit/cli/test_base.py
@@ -366,6 +366,7 @@ class Test_Command:
                 console_port=command.console_port,
                 redirect_stdouts=command.redirect_stdouts or False,
                 redirect_stdouts_level=command.redirect_stdouts_level,
+                override_logging=command.override_logging or False,
                 loop=loop,
                 daemon=command.daemon,
             )

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -38,8 +38,10 @@ class Test_Worker:
         assert not w2.redirect_stdouts
         w3 = Worker(app, redirect_stdouts_level="DEBUG")
         assert w3.redirect_stdouts_level == 10
-        w4 = Worker(app, logging_config={"foo": 1})
-        assert w4.logging_config == {"foo": 1}
+        w4 = Worker(app, override_logging=False)
+        assert not w4.override_logging
+        w5 = Worker(app, logging_config={"foo": 1})
+        assert w5.logging_config == {"foo": 1}
 
     def test_set_sensors(self, app):
         assert Worker(app, sensors=[1, 2]).sensors == {1, 2}


### PR DESCRIPTION
* Add override_logging argument to Worker 
* Add worker_override_logging to App
* Update documentation
* Update tests

## Description

Allow user to decide if override_logging shoud be enabled or not.
It is forced by faust.Worker to be enabled right now.

It resolve Issue #634 

