### PR TITLE
Remove loop argument from `aiokafka` driver

### DIFF
--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -1242,12 +1242,9 @@ class Producer(base.Producer):
         self, transactional_id: Optional[str] = None
     ) -> aiokafka.AIOKafkaProducer:
         return self._producer_type(
-            loop=self.loop,
-            **{
-                **self._settings_default(),
-                **self._settings_auth(),
-                **self._settings_extra(),
-            },
+            **self._settings_default(),
+            **self._settings_auth(),
+            **self._settings_extra(),
             transactional_id=transactional_id,
         )
 

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -1242,9 +1242,11 @@ class Producer(base.Producer):
         self, transactional_id: Optional[str] = None
     ) -> aiokafka.AIOKafkaProducer:
         return self._producer_type(
-            **self._settings_default(),
-            **self._settings_auth(),
-            **self._settings_extra(),
+            **{
+                **self._settings_default(),
+                **self._settings_auth(),
+                **self._settings_extra(),
+            }
             transactional_id=transactional_id,
         )
 

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -1246,7 +1246,7 @@ class Producer(base.Producer):
                 **self._settings_default(),
                 **self._settings_auth(),
                 **self._settings_extra(),
-            }
+            },
             transactional_id=transactional_id,
         )
 

--- a/tests/unit/transport/drivers/test_aiokafka.py
+++ b/tests/unit/transport/drivers/test_aiokafka.py
@@ -1391,7 +1391,6 @@ class ProducerBaseTest:
                 max_request_size=max_request_size,
                 compression_type=compression_type,
                 security_protocol=security_protocol,
-                loop=producer.loop,
                 partitioner=producer.partitioner,
                 transactional_id=None,
                 api_version=api_version,


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust-streaming.github.io/faust/contributing.html).

## Description
When using `faust`, you get the following deprecation warning:
```
/path/to/proj/venv/.venv/lib/python3.9/site-packages/faust/transport/drivers/aiokafka.py:1244: DeprecationWarning: The loop argument is deprecated since 0.7.1, and scheduled for removal in 0.9.0
    return self._producer_type(
```
This pr simply removes the `loop=self.loop` line in `aiokafka` drivers.