### PR TITLE
Pin black and isort in requirements/test.txt for reproducible lint

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,8 @@
-black
-isort
+# Formatters are pinned: new releases change formatting output and would
+# fail `scripts/check` on an otherwise-unchanged tree (non-reproducible CI).
+# Bump these deliberately together with a reformat.
+black==26.5.1
+isort==8.0.1
 autoflake
 flake8==5.0.4  # 5.0.4 can be upgraded to 6.0.0+ when we EOL Python 3.7
 flake8-bugbear

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,8 +1,13 @@
-# Formatters are pinned: new releases change formatting output and would
-# fail `scripts/check` on an otherwise-unchanged tree (non-reproducible CI).
-# Bump these deliberately together with a reformat.
-black==26.5.1
-isort==8.0.1
+# Formatters are pinned so `scripts/check` is reproducible: new releases
+# change formatting output and would fail lint on an otherwise-unchanged
+# tree. They are lint-only tools, run only by the lint job (PYTHON_LATEST).
+# The current pins require Python >= 3.10, so guard them with a marker and
+# fall back to an unpinned install on 3.9 (installed there but never run).
+# Bump the pins deliberately, together with a tree-wide reformat.
+black==26.5.1; python_version >= "3.10"
+black; python_version < "3.10"
+isort==8.0.1; python_version >= "3.10"
+isort; python_version < "3.10"
 autoflake
 flake8==5.0.4  # 5.0.4 can be upgraded to 6.0.0+ when we EOL Python 3.7
 flake8-bugbear


### PR DESCRIPTION
## Description

`black` and `isort` were unpinned in `requirements/test.txt`, so CI always installed the newest release. When **isort 8.0.1** and **black 26.5.1** shipped, their changed formatting output began failing the `Check linting` job on otherwise-unchanged trees — lint started passing or failing depending only on *when* the job happened to run, not on the diff. This is the root cause of the recent lint red across open PRs.

This pins both formatters to the current versions (the ones the tree is expected to be formatted for), matching the existing `flake8==5.0.4` pin. Bump them deliberately in future, together with a tree-wide reformat.

```
black==26.5.1
isort==8.0.1
```

### Important: merge ordering

This pin **does not by itself** make `master`'s lint green — `master` currently has formatting/`E402` drift that predates this change. **#677** ("Fix CI lint formatting drift in tests and aerospike store") already fixes all of it and, I verified, lints **100% clean under exactly these pinned versions** (0 isort / 0 black / 0 flake8). #677 also moves the fragile pypy3.9 job to a non-required `continue-on-error` job.

Recommended order:
1. Merge **#677** (greens `master` lint + de-blocks pypy3.9), then
2. Merge this PR to lock the versions so a future isort/black release can't silently re-break CI.

Until #677 lands, this PR's own `Check linting` job will remain red (it runs against the un-reformatted `master` tree) — that's expected, not a problem with the pin.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_