### PR TITLE
Document OpenTelemetry instrumentation in sensors user guide

### DIFF
--- a/docs/userguide/sensors.rst
+++ b/docs/userguide/sensors.rst
@@ -258,6 +258,39 @@ Class: ``TableState``
         .. autoattribute:: keys_deleted
             :noindex:
 
+.. _sensor-opentelemetry:
+
+OpenTelemetry
+=============
+
+Faust can be instrumented with `OpenTelemetry`_ using the official
+`opentelemetry-instrumentation-faust`_ package:
+
+.. sourcecode:: console
+
+    $ pip install opentelemetry-instrumentation-faust
+
+The instrumentation uses the sensor API described on this page to
+record a producer span for every message sent to Kafka (injecting the
+span context into the message headers), and a consumer span for every
+event processed by an agent (continuing the trace from the incoming
+message headers).
+
+Instrument faust before creating the app:
+
+.. sourcecode:: python
+
+    import faust
+    from opentelemetry.instrumentation.faust import FaustInstrumentor
+
+    FaustInstrumentor().instrument()
+
+    app = faust.App('example', broker='kafka://localhost:9092')
+
+.. _`OpenTelemetry`: https://opentelemetry.io/
+.. _`opentelemetry-instrumentation-faust`:
+    https://pypi.org/project/opentelemetry-instrumentation-faust/
+
 .. _sensor-reference:
 
 Sensor API Reference


### PR DESCRIPTION
Point to the opentelemetry-instrumentation-faust package, which uses
the sensor API to trace messages produced to Kafka and events
processed by agents.

Assisted-by: Claude Fable 5

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NoKAa2xLqorEdDQKh77E8Q