### PR TITLE
fix(aiokafka): keep Faust assignor for changelog tables; drop Python 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,7 +42,7 @@ jobs:
       # for example if a test fails only when Cython is enabled
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         use-cython: ['true', 'false']
         experimental: [false]
     env:

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Yes! Use the `asyncio` reactor implementation: https://twistedmatrix.com/documen
 
 ### Will you support Python 2.7 or Python 3.5
 
-No. Faust requires Python 3.8 or later, since it heavily uses features that were
+No. Faust requires Python 3.10 or later, since it heavily uses features that were
 introduced in Python 3.6 (`async`, `await`, variable type annotations).
 
 ### I get a maximum number of open files exceeded error by RocksDB when running a Faust app locally. How can I fix this

--- a/docs/includes/faq.txt
+++ b/docs/includes/faq.txt
@@ -55,7 +55,7 @@ https://twistedmatrix.com/documents/17.1.0/api/twisted.internet.asyncioreactor.h
 Will you support Python 2.7 or Python 3.5?
 ------------------------------------------
 
-No. Faust requires Python 3.8 or later, since it heavily uses features that were
+No. Faust requires Python 3.10 or later, since it heavily uses features that were
 introduced in Python 3.6 (`async`, `await`, variable type annotations).
 
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -162,7 +162,7 @@ What do I need?
 
     - RocksDB 5.0 or later, :pypi:`python-rocksdb`
 
-Faust requires Python 3.8 or later, and a running Kafka broker.
+Faust requires Python 3.10 or later, and a running Kafka broker.
 
 There's no plan to support earlier Python versions.
 Please get in touch if this is something you want to work on.

--- a/docs/userguide/application.rst
+++ b/docs/userguide/application.rst
@@ -1374,7 +1374,7 @@ setuptools to install a command-line program for your project.
             include_package_data=True,
             zip_safe=False,
             install_requires=['faust'],
-            python_requires='~=3.8',
+            python_requires='~=3.10',
         )
 
     For inspiration you can also look to the `setup.py` files in the

--- a/examples/django/setup.py
+++ b/examples/django/setup.py
@@ -95,7 +95,7 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['ez_setup', 'tests', 'tests.*']),
     include_package_data=True,
-    python_requires='>=3.8.0',
+    python_requires='>=3.10.0',
     keywords=[],
     zip_safe=False,
     install_requires=reqs('default.txt'),

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -42,7 +42,7 @@ from aiokafka.errors import (
 )
 from aiokafka.partitioner import DefaultPartitioner, murmur2
 from aiokafka.protocol.admin import CreateTopicsRequest
-from aiokafka.protocol.metadata import MetadataRequest_v1
+from aiokafka.protocol.metadata import MetadataRequest
 from aiokafka.structs import OffsetAndMetadata, TopicPartition as _TopicPartition
 from aiokafka.util import parse_kafka_version
 from mode import Service, get_logger
@@ -95,6 +95,8 @@ __all__ = ["Consumer", "Producer", "Transport"]
 #         'Please install robinhood-aiokafka, not aiokafka')
 
 logger = get_logger(__name__)
+
+_AIOKAFKA_HAS_API_VERSION = Version(aiokafka.__version__) < Version("0.13.0")
 
 DEFAULT_GENERATION_ID = OffsetCommitRequest.DEFAULT_GENERATION_ID
 
@@ -511,9 +513,13 @@ class AIOKafkaConsumerThread(ConsumerThread):
         conf = self.app.conf
         if self.consumer.in_transaction:
             isolation_level = "read_committed"
+        # Table recovery depends on app.assignor state to map changelog
+        # active/standby partitions. Keep Faust assignor enabled whenever
+        # this app has changelog tables configured.
+        has_changelog_tables = bool(self.app.tables.changelog_topics)
         self._assignor = (
             self.app.assignor
-            if self.app.conf.table_standby_replicas > 0
+            if self.app.conf.table_standby_replicas > 0 or has_changelog_tables
             else RoundRobinPartitionAssignor
         )
         auth_settings = credentials_to_aiokafka_auth(
@@ -1513,7 +1519,7 @@ class Transport(base.Transport):
         for node_id in nodes:
             if node_id is None:
                 raise NotReady("Not connected to Kafka Broker")
-            request = MetadataRequest_v1([])
+            request = MetadataRequest([])
             wait_result = await owner.wait(
                 client.send(node_id, request),
                 timeout=timeout,
@@ -1546,7 +1552,6 @@ class Transport(base.Transport):
             owner.log.debug("Topic %r exists, skipping creation.", topic)
             return
 
-        protocol_version = 1
         extra_configs = config or {}
         config = self._topic_config(retention, compacting, deleting)
         config.update(extra_configs)
@@ -1563,7 +1568,7 @@ class Transport(base.Transport):
             else:
                 raise Exception("Controller node is None")
 
-        request = CreateTopicsRequest[protocol_version](
+        request = CreateTopicsRequest(
             [(topic, partitions, replication, [], list(config.items()))],
             timeout,
             False,

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -42,7 +42,7 @@ from aiokafka.errors import (
 )
 from aiokafka.partitioner import DefaultPartitioner, murmur2
 from aiokafka.protocol.admin import CreateTopicsRequest
-from aiokafka.protocol.metadata import MetadataRequest
+from aiokafka.protocol.metadata import MetadataRequest, MetadataRequest_v1
 from aiokafka.structs import OffsetAndMetadata, TopicPartition as _TopicPartition
 from aiokafka.util import parse_kafka_version
 from mode import Service, get_logger
@@ -85,8 +85,6 @@ from faust.types import (
 from faust.types.auth import CredentialsT
 from faust.types.transports import ConsumerT, PartitionerT, ProducerT
 from faust.utils.tracing import noop_span, set_current_span, traced_from_parent_span
-
-_AIOKAFKA_HAS_API_VERSION = Version(aiokafka.__version__) < Version("0.13.0")
 
 __all__ = ["Consumer", "Producer", "Transport"]
 
@@ -1519,7 +1517,11 @@ class Transport(base.Transport):
         for node_id in nodes:
             if node_id is None:
                 raise NotReady("Not connected to Kafka Broker")
-            request = MetadataRequest([])
+            if _AIOKAFKA_HAS_API_VERSION:
+                # aiokafka < 0.13: MetadataRequest is a versioned list.
+                request = MetadataRequest_v1([])
+            else:
+                request = MetadataRequest([])
             wait_result = await owner.wait(
                 client.send(node_id, request),
                 timeout=timeout,
@@ -1568,11 +1570,16 @@ class Transport(base.Transport):
             else:
                 raise Exception("Controller node is None")
 
-        request = CreateTopicsRequest(
+        create_topics_args = (
             [(topic, partitions, replication, [], list(config.items()))],
             timeout,
             False,
         )
+        if _AIOKAFKA_HAS_API_VERSION:
+            # aiokafka < 0.13: CreateTopicsRequest is indexed by protocol version.
+            request = CreateTopicsRequest[1](*create_topics_args)
+        else:
+            request = CreateTopicsRequest(*create_topics_args)
         wait_result = await owner.wait(
             client.send(controller_node, request),
             timeout=timeout,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "faust-streaming"
 description = "Python Stream Processing. A Faust fork"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = [
     "version",
     "optional-dependencies",
@@ -26,8 +26,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ LDFLAGS = []
 LIBRARIES = []
 E_UNSUPPORTED_PYTHON = NAME + " 1.0 requires Python %%s or later!"
 
-if sys.version_info < (3, 8):
-    raise Exception(E_UNSUPPORTED_PYTHON % ("3.8",))  # NOQA
+if sys.version_info < (3, 10):
+    raise Exception(E_UNSUPPORTED_PYTHON % ("3.10",))  # NOQA
 
 from pathlib import Path  # noqa
 
@@ -198,7 +198,7 @@ def do_setup(**kwargs):
         # PEP-561: https://www.python.org/dev/peps/pep-0561/
         package_data={"faust": ["py.typed"]},
         include_package_data=True,
-        python_requires=">=3.8.0",
+        python_requires=">=3.10.0",
         zip_safe=False,
         install_requires=reqs("requirements.txt"),
         tests_require=reqs("test.txt"),

--- a/tests/unit/transport/drivers/test_aiokafka.py
+++ b/tests/unit/transport/drivers/test_aiokafka.py
@@ -796,6 +796,26 @@ class Test_AIOKafkaConsumerThread(AIOKafkaConsumerThreadFixtures):
             isolation_level="read_committed",
         )
 
+    def test__create_worker_consumer__uses_roundrobin_without_tables(
+        self, *, cthread, app
+    ):
+        app.conf.table_standby_replicas = 0
+        app.tables._changelogs.clear()
+        transport = cthread.transport
+        with patch("aiokafka.AIOKafkaConsumer"):
+            cthread._create_worker_consumer(transport)
+        assert cthread._assignor is mod.RoundRobinPartitionAssignor
+
+    def test__create_worker_consumer__uses_faust_assignor_with_changelog_topics(
+        self, *, cthread, app
+    ):
+        app.conf.table_standby_replicas = 0
+        app.tables._changelogs["app-foo-changelog"] = Mock(name="table")
+        transport = cthread.transport
+        with patch("aiokafka.AIOKafkaConsumer"):
+            cthread._create_worker_consumer(transport)
+        assert cthread._assignor is app.assignor
+
     def assert_create_worker_consumer(
         self,
         cthread,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = 3.12,3.11,3.10,3.9,3.8,flake8,apicheck,configcheck,typecheck,docstyle,bandit,spell
+envlist = 3.12,3.11,3.10,flake8,apicheck,configcheck,typecheck,docstyle,bandit,spell
 
 [testenv]
 deps=
@@ -20,8 +20,6 @@ basepython =
     3.12,flake8,apicheck,linkcheck,configcheck,typecheck,docstyle,bandit,spell: python3.12
     3.11,flake8,apicheck,linkcheck,configcheck,typecheck,docstyle,bandit,spell: python3.11
     3.10,flake8,apicheck,linkcheck,configcheck,typecheck,docstyle,bandit,spell: python3.10
-    3.9,flake8,apicheck,linkcheck,configcheck,typecheck,docstyle,bandit,spell: python3.9
-    3.8,flake8,apicheck,linkcheck,configcheck,typecheck,docstyle,bandit,spell: python3.8
 
 [testenv:apicheck]
 setenv =


### PR DESCRIPTION
## Description

Rebases **#676** (by @Mopsgeschwindigkeit / Marco Moser) onto current master. #676's branch could not be updated in place (external fork), so this re-applies its two commits — authorship preserved — on top of the merged #674/#677/#679/#680 work, where they apply cleanly and lint green.

Supersedes #676.

### What's here (unchanged from #676)

1. **Keep the Faust assignor when changelog tables exist.** Table recovery relies on `app.assignor` to map changelog active/standby partitions, but the worker consumer only used the Faust assignor when `table_standby_replicas > 0`. It now also stays enabled whenever the app has changelog tables:
   ```python
   has_changelog_tables = bool(self.app.tables.changelog_topics)
   self._assignor = (
       self.app.assignor
       if self.app.conf.table_standby_replicas > 0 or has_changelog_tables
       else RoundRobinPartitionAssignor
   )
   ```
   Covered by two new unit tests (round-robin without tables; Faust assignor with changelog topics).

2. **aiokafka 0.13+ admin-request compatibility:** `MetadataRequest_v1` → `MetadataRequest`, and `CreateTopicsRequest[protocol_version]` → `CreateTopicsRequest`.

3. **Drops Python 3.9 (and pypy3.9) support**, bumping `requires-python` to `>=3.10` across `pyproject.toml`/`setup.py`/`tox.ini` and the CI matrix. This is an intentional support-policy change.

### Verification

- Cherry-picked cleanly onto master (the `faust/__init__.py` / `aerospike.py` lint hunks from #676 were already landed via #677, so they no-op'd).
- Lint clean (isort / black / flake8 all 0).
- `tests/unit/transport/drivers/test_aiokafka.py`: **136 passed, 23 skipped** (the +2 vs master are the new assignor tests).

Credit: original commits by Marco Moser (@Mopsgeschwindigkeit), smaxtec.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_