### PR TITLE
Add codecov.yml with a 1% coverage threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+# Codecov configuration.
+#
+# Without this file Codecov applies its default project status of
+# target: auto / threshold: 0%, which fails CI on any coverage decrease at
+# all -- including the sub-0.1% jitter that comes from async/threaded lines
+# being counted slightly differently between runs. Give the gate a 1%
+# threshold so it tolerates that noise while still catching real regressions.
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+# Suppress the per-PR coverage comment; the status checks carry the signal.
+comment: false


### PR DESCRIPTION
## Description

The repo has no Codecov config, so Codecov applies its **default** project status — `target: auto`, `threshold: 0%` — which fails the `codecov/project` check on **any** coverage decrease at all. In practice the drops are sub-0.1% jitter from async/threaded lines being counted slightly differently between runs (not real regressions), and they've been forcing admin-merges on otherwise-green PRs.

This adds a root `codecov.yml` giving `project` and `patch` a **1% threshold** — enough slack to absorb the noise while still flagging a genuine coverage regression — and disables the per-PR Codecov comment (the status checks already carry the signal).

```yaml
coverage:
  status:
    project:
      default:
        target: auto
        threshold: 1%
    patch:
      default:
        target: auto
        threshold: 1%
comment: false
```

Notes:
- Repo-wide policy change: it applies to all PRs once merged (it does not retroactively re-flip an already-run check; a re-run picks it up).
- Validated as well-formed YAML with the standard Codecov schema.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_