### PR TITLE
Fix release artifact handling for upload-artifact@v4 (would drop wheels/sdist on next release)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -123,8 +123,9 @@ jobs:
         uses: pypa/cibuildwheel@v2.10.1
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-artifacts
+          name: cibw-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
+          if-no-files-found: error
   build_sdist:
     name: 📦 Build the source distribution
     runs-on: ubuntu-latest
@@ -143,8 +144,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         name: Upload build artifacts
         with:
-          name: sdist-artifact
+          name: cibw-sdist
           path: dist/*.tar.gz
+          if-no-files-found: error
   publish:
     name: 📦 Publish to PyPI
     runs-on: ubuntu-latest
@@ -154,17 +156,14 @@ jobs:
     environment: pypi
     if: github.event_name == 'release' && github.event.action == 'created'
     steps:
-      - name: Download the sdist artifact
-        uses: actions/download-artifact@v4.1.7
+      - name: Download all build artifacts (sdist + every wheel)
+        uses: actions/download-artifact@v4
         with:
-          name: sdist-artifact
-          path: dist
-      - name: Download the wheel artifact
-        uses: actions/download-artifact@v4.1.7
-        with:
-          pattern: "*artifact*"
+          pattern: cibw-*
           merge-multiple: true
+          path: dist
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
## Description

The release workflow can publish an **incomplete** set of files (missing wheels and/or the sdist) even on a green run. This is the `upload-artifact` v3→v4 breaking-change trap.

### Root cause

**#649** (`af0ed799`, Nov 2024) bumped `upload-artifact`/`download-artifact` from **v3 → v4** but kept the v3-era pattern:

- All three `build_wheels` matrix legs (`ubuntu-20.04`, `macos-13`, `macos-14`) uploaded under the **same** name `wheel-artifacts`.
- `publish` downloaded the sdist by name into `dist/`, then downloaded wheels with `pattern: "*artifact*"` and **no `path:`** (so they land in the workspace root, not `dist/` — and `gh-action-pypi-publish` publishes from `dist/`).

Under **v3**, multiple uploads to the same name were *merged*, so this worked. Under **v4** that implicit merge is gone: each upload is its own immutable artifact and re-uploading the same name **fails**. So the matrix legs collide on `wheel-artifacts`, and the wheel download misses `dist/`.

### Why it hasn't broken a release yet

The most recent release, **v0.11.3 (Aug 2024)**, predates #649 and still used `upload-artifact@v3`, so it shipped a complete set (sdist + macOS/manylinux wheels — verified on PyPI). The bug is **latent**: the **next** release (first one after #649) is where it bites.

### The fix (canonical cibuildwheel-on-v4 pattern)

- Unique artifact names per uploader: `cibw-wheels-${{ matrix.os }}` and `cibw-sdist`.
- Single collection in `publish`: `download-artifact@v4` with `pattern: cibw-*`, `merge-multiple: true`, `path: dist`.
- `skip-existing: true` on the publish step so a re-run can backfill missing files idempotently.
- `if-no-files-found: error` on the uploads so an empty build fails loudly instead of silently publishing nothing.

### Notes / follow-ups

- Release jobs only run on `release: created`, so this can't be exercised by PR CI — it's validated by inspection + valid-YAML check. Consider adding a `workflow_dispatch` trigger (gated alongside the `release` condition) so a fixed release can be re-published on demand, and a post-publish check asserting the index has both an sdist and the expected wheels.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_