### PR TITLE
Remove dead opentracing reference from the confluent driver

### DIFF
--- a/faust/transport/drivers/confluent.py
+++ b/faust/transport/drivers/confluent.py
@@ -208,8 +208,6 @@ class ConfluentConsumerThread(ConsumerThread):
     _consumer: Optional[AsyncConsumer] = None
     _assigned: bool = False
 
-    # _pending_rebalancing_spans: Deque[opentracing.Span]
-
     tp_last_committed_at: MutableMapping[TP, float]
     time_started: float
 


### PR DESCRIPTION
## Description

`ConfluentConsumerThread` carried a commented-out attribute copied from the aiokafka driver:

```python
# _pending_rebalancing_spans: Deque[opentracing.Span]
```

The confluent driver never used it and doesn't import `opentracing`, so this stale comment was the file's only remaining `opentracing` reference. Removing it leaves `faust/transport/drivers/confluent.py` with **zero** opentracing references.

Note: there was no actual `import opentracing` to drop here — just this dead comment. Trivial, no runtime impact; flake8/black clean and the module still imports.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_