### PR TITLE
Add unit tests for functional/platforms/agent_stopper utils (real coverage)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -31,9 +31,7 @@ omit =
     */faust/tables/recovery.py
 
     # not needed
-    */faust/utils/functional.py
     */faust/utils/iso8601.py
-    */faust/utils/platforms.py
     */faust/utils/tracing.py
     */faust/types/*
     */faust/__main__.py

--- a/tests/unit/utils/test_agent_stopper.py
+++ b/tests/unit/utils/test_agent_stopper.py
@@ -1,0 +1,13 @@
+from unittest.mock import Mock
+
+import pytest
+
+from faust.utils.agent_stopper import agent_stopper
+
+
+@pytest.mark.asyncio
+async def test_agent_stopper_crashes_app():
+    app = Mock(name="app")
+    await agent_stopper(app)
+    # It must force a non-zero exit by crashing the app with a RuntimeError.
+    app._crash.assert_called_once_with(RuntimeError)

--- a/tests/unit/utils/test_functional.py
+++ b/tests/unit/utils/test_functional.py
@@ -1,6 +1,6 @@
 import pytest
 
-from faust.utils.functional import consecutive_numbers
+from faust.utils.functional import consecutive_numbers, translate
 
 
 @pytest.mark.parametrize(
@@ -14,3 +14,17 @@ from faust.utils.functional import consecutive_numbers
 )
 def test_consecutive_numbers(numbers, expected):
     assert next(consecutive_numbers(numbers), None) == expected
+
+
+@pytest.mark.parametrize(
+    "table,s,expected",
+    [
+        ({".": "_", "@": "."}, "foo.bar@baz", "foo_bar.baz"),
+        ({".": "_"}, "foo.bar", "foo_bar"),
+        # multi-character patterns/replacements, not just single chars
+        ({"foo": "bar"}, "foofoo", "barbar"),
+        ({}, "unchanged", "unchanged"),
+    ],
+)
+def test_translate(table, s, expected):
+    assert translate(table, s) == expected

--- a/tests/unit/utils/test_platforms.py
+++ b/tests/unit/utils/test_platforms.py
@@ -1,0 +1,35 @@
+import builtins
+import resource
+from unittest.mock import patch
+
+from faust.utils.platforms import max_open_files
+
+
+@patch("resource.getrlimit", return_value=(1024, 4096))
+def test_max_open_files__returns_hard_limit(getrlimit):
+    assert max_open_files() == 4096
+
+
+@patch("platform.system", return_value="Linux")
+@patch("resource.getrlimit", return_value=(1024, resource.RLIM_INFINITY))
+def test_max_open_files__infinity_non_darwin(getrlimit, system):
+    assert max_open_files() is None
+
+
+@patch("subprocess.check_output", return_value=b"kern.maxfilesperproc: 24576")
+@patch("platform.system", return_value="Darwin")
+@patch("resource.getrlimit", return_value=(1024, resource.RLIM_INFINITY))
+def test_max_open_files__infinity_darwin_uses_sysctl(getrlimit, system, check_output):
+    assert max_open_files() == 24576
+
+
+def test_max_open_files__no_resource_module():
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "resource":
+            raise ImportError("no resource module")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        assert max_open_files() is None


### PR DESCRIPTION
## Description

Coverage "quick wins" — convert three gaps into **genuine tests** rather than leaving them excluded from coverage. Each target goes to **100%**:

| Module | Before | Change |
|---|---|---|
| `faust/utils/functional.py` | 75% (only `consecutive_numbers` tested) | Add a `translate()` test (incl. multi-char patterns and empty table) → **100%**; remove its `.coveragerc` omit |
| `faust/utils/platforms.py` | 0% (omitted) | Test `max_open_files()` across all branches — normal hard limit, `RLIM_INFINITY` on non-Darwin, `RLIM_INFINITY` on Darwin (via `sysctl`), and missing `resource` module → **100%**; remove its `.coveragerc` omit |
| `faust/utils/agent_stopper.py` | 0% (measured, untested) | Test that `agent_stopper()` crashes the app with `RuntimeError` → **100%** |

So `functional.py` and `platforms.py` come **off** the `.coveragerc` omit list — their coverage is now real and enforced going forward, not hidden.

### Notes

- The `platforms` tests use stacked `@patch` decorators instead of a parenthesized multi-context `with (...)`: black (unpinned/`26.x`, no `target-version`) would rewrite the latter to 3.10+ syntax, which would break the Python 3.9 matrix job. The decorator form stays valid on 3.9 and is black-stable.
- Lint clean (flake8 / isort / black); 13 tests, all passing.

This is the first batch; further un-omissions (e.g. `windows.py`, `assignor/*`, the CLI) are natural follow-ups.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_