### PR TITLE
Modernize CI: wheel runners, Windows wheels, and test matrix (drop 3.9, require 3.14)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,7 +42,7 @@ jobs:
       # for example if a test fails only when Cython is enabled
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         use-cython: ['true', 'false']
         experimental: [false]
     env:
@@ -68,7 +68,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
   test-pypy:
-    name: 'Python pypy3.9/Cython: false'
+    name: 'Python pypy3.11/Cython: false'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: pypy3.9
+          python-version: pypy3.11
           cache: pip
           cache-dependency-path: requirements/test.txt
       - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -115,8 +115,10 @@ jobs:
     strategy:
       matrix:
         # Modern, supported runner images (ubuntu-20.04 was retired in 2025).
-        # macos-15-intel -> x86_64 wheels, macos-14 -> arm64 wheels.
-        os: [ubuntu-latest, macos-15-intel, macos-14]
+        # macos-15-intel -> x86_64 wheels, macos-14 -> arm64 wheels,
+        # windows-2022 -> AMD64 wheels. Build config lives in
+        # pyproject.toml's [tool.cibuildwheel] (cp3*, auto64, Cython).
+        os: [ubuntu-latest, macos-15-intel, macos-14, windows-2022]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -114,13 +114,15 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'created'
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-13, macos-14]
+        # Modern, supported runner images (ubuntu-20.04 was retired in 2025).
+        # macos-15-intel -> x86_64 wheels, macos-14 -> arm64 wheels.
+        os: [ubuntu-latest, macos-15-intel, macos-14]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.10.1
+        uses: pypa/cibuildwheel@v2.21.3
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Operating System :: POSIX",
     "Operating System :: POSIX :: Linux",

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,13 +1,9 @@
 # Formatters are pinned so `scripts/check` is reproducible: new releases
 # change formatting output and would fail lint on an otherwise-unchanged
 # tree. They are lint-only tools, run only by the lint job (PYTHON_LATEST).
-# The current pins require Python >= 3.10, so guard them with a marker and
-# fall back to an unpinned install on 3.9 (installed there but never run).
 # Bump the pins deliberately, together with a tree-wide reformat.
-black==26.5.1; python_version >= "3.10"
-black; python_version < "3.10"
-isort==8.0.1; python_version >= "3.10"
-isort; python_version < "3.10"
+black==26.5.1
+isort==8.0.1
 autoflake
 flake8==5.0.4  # 5.0.4 can be upgraded to 6.0.0+ when we EOL Python 3.7
 flake8-bugbear


### PR DESCRIPTION
## Description

Modernizes `python-package.yml`: current GitHub runner images for the release wheel build, Windows wheels, and a refreshed CPython test matrix.

### Release wheel build

The `build_wheels` matrix pinned **`ubuntu-20.04`**, whose runner image GitHub **retired in April 2025** — that job can no longer be scheduled. `macos-13` is also deprecating, and **`pypa/cibuildwheel@v2.10.1`** (Sept 2022) predates Python 3.12/3.13 wheels and the newer runner images. This job only runs on `release`, so the breakage is latent (same class as the dropped-artifact bug fixed in #684).

- **Runners:** `ubuntu-20.04 → ubuntu-latest`; `macos-13 → macos-15-intel` (x86_64); `macos-14` kept (arm64).
- **cibuildwheel:** `v2.10.1 → v2.21.3`.
- **Windows wheels:** added **`windows-2022`** → AMD64 CPython wheels. `pyproject.toml` already declares Windows support and carries a `[tool.cibuildwheel]` config (`build = "cp3*"`, `archs = ["auto64"]`, `before-build = "pip install Cython"`); `setup.py` already handles `win32` (links `ws2_32`, skips gcc-only warning flags), so the existing build config applies unchanged. The per-runner artifact name (`cibw-wheels-${{ matrix.os }}`) stays unique for the publish job's `cibw-*` download+merge.

### Test matrix

- **Add Python 3.14** (with and without Cython) to `test-pytest`. 3.13 was already present; both now run under the required `✅ Ensure the required checks passing` gate. 3.14 is GA (Oct 2025), so no prerelease handling is needed.
- **Drop Python 3.9:** bump the PyPy lane `pypy3.9 → pypy3.11` (stays non-required / `continue-on-error`), and remove the 3.9 formatter fallbacks from `requirements/test.txt` (the `black`/`isort` pins now install unconditionally since the minimum supported Python is 3.10).
- **`pyproject.toml`:** add the 3.13 and 3.14 classifiers.

The other two workflows (`codeql-analysis`, `gh-pages`) already run on `ubuntu-latest` with current action versions — no changes needed.

### Validation notes

- YAML/TOML validated; CPython matrix resolves to `['3.10','3.11','3.12','3.13','3.14']`; no `3.9` references remain in CI or requirements.
- **3.14 is now a required check**, so if a runtime dependency isn't yet 3.14-ready the gate will flag it here — that's the intended signal.
- The wheel/publish jobs are gated to `release` events, so this PR's checks don't build wheels; the new runners and first-ever Windows build get exercised at the next release (or a manual `workflow_dispatch`/test tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
