### PR TITLE
ci: test on Python 3.14 with and without Cython

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,7 +42,7 @@ jobs:
       # for example if a test fails only when Cython is enabled
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         use-cython: ['true', 'false']
         experimental: [false]
     env:


### PR DESCRIPTION
## Description

Adds `3.14` to the test matrix, producing `Python 3.14/Cython: true` and `Python 3.14/Cython: false` jobs alongside the existing 3.13 legs. All matrix legs feed the aggregate `✅ Ensure the required checks passing` job, so requiring that single check in branch protection makes tests on 3.13 and 3.14 (with and without Cython) required automatically.

Python 3.9 needs no code change here: it was already removed from the matrix and from `python_requires` (`>=3.10.0`). The lingering `Python 3.9/Cython: false|true` required status checks exist only as stale contexts in branch protection and should be deleted there (they reference job names that no longer run, so they stay pending forever).

Note on sequencing: the 3.14 legs depend on a `mode-streaming` release carrying the event-loop fix from faust-streaming/mode#72 — Python 3.14 removed implicit event-loop creation, which mode relied on when `Service.loop` is resolved at import time (e.g. `@app.agent()` at module scope). Until that release ships, the 3.14 jobs are expected to fail at import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgnKFtXZbCjXNoVNWa5JLd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgnKFtXZbCjXNoVNWa5JLd)_