### PR TITLE
Fix committed-offset bookkeeping advancing when commit fails

### DIFF
--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -1053,8 +1053,8 @@ class Consumer(Service, ConsumerT):
                 on_timeout.info("+tables.on_commit")
                 self.app.tables.on_commit(committable_offsets)
                 on_timeout.info("-tables.on_commit")
-        self._committed_offset.update(committable_offsets)
-        self.app.monitor.on_tp_commit(committable_offsets)
+                self._committed_offset.update(committable_offsets)
+                self.app.monitor.on_tp_commit(committable_offsets)
         return did_commit
 
     def _filter_tps_with_pending_acks(

--- a/tests/unit/transport/test_consumer.py
+++ b/tests/unit/transport/test_consumer.py
@@ -946,9 +946,10 @@ class TestConsumer:
 
     @pytest.mark.asyncio
     async def test_commit_offsets(self, *, consumer):
-        consumer._commit = AsyncMock(name="_commit")
+        consumer._commit = AsyncMock(name="_commit", return_value=True)
         consumer.current_assignment.update({TP1, TP2})
         consumer.app.producer.flush = AsyncMock()
+        consumer.app.monitor.on_tp_commit = Mock(name="on_tp_commit")
         await consumer._commit_offsets(
             {
                 TP1: 3003,
@@ -961,6 +962,15 @@ class TestConsumer:
                 TP2: 6006,
             }
         )
+        # On a successful commit, bookkeeping must advance.
+        consumer.app.monitor.on_tp_commit.assert_called_once_with(
+            {
+                TP1: 3003,
+                TP2: 6006,
+            }
+        )
+        assert consumer._committed_offset[TP1] == 3003
+        assert consumer._committed_offset[TP2] == 6006
 
     @pytest.mark.asyncio
     async def test_commit_offsets__did_not_commit(self, *, consumer):
@@ -969,6 +979,8 @@ class TestConsumer:
         consumer.app.producer.flush = AsyncMock()
         consumer.current_assignment.update({TP1, TP2})
         consumer.app.tables = Mock(name="app.tables")
+        consumer.app.monitor.on_tp_commit = Mock(name="on_tp_commit")
+        committed_offset_before = dict(consumer._committed_offset)
         await consumer._commit_offsets(
             {
                 TP1: 3003,
@@ -977,6 +989,11 @@ class TestConsumer:
             }
         )
         consumer.app.tables.on_commit.assert_not_called()
+        # Bookkeeping must not advance when the underlying commit failed
+        # (see faust-streaming/faust#316): a failed commit must not make
+        # Faust believe those offsets were actually committed.
+        consumer.app.monitor.on_tp_commit.assert_not_called()
+        assert consumer._committed_offset == committed_offset_before
 
     @pytest.mark.asyncio
     async def test_commit_offsets__in_transaction(self, *, consumer):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://faust-streaming.github.io/faust/contributing.html).

## Description

Fixes #316.

`Consumer._commit_offsets` (`faust/transport/consumer.py`) updated `self._committed_offset` and fired `self.app.monitor.on_tp_commit(...)` **unconditionally**, outside the `if did_commit:` guard that already existed for the `tables.on_commit(...)` call two lines above.

On any transient commit failure (e.g. `UnknownMemberIdError` during a rebalance — the scenario in the original report), Faust's internal bookkeeping silently advanced to record those offsets as committed even though the underlying Kafka commit never happened. A later `_should_commit()` check (`committed = self._committed_offset[tp]; return committed is None or offset > committed`) would then see those offsets as already committed and skip retrying them — risking real offset loss under the default at-least-once guarantee.

### Fix

Move `self._committed_offset.update(...)` and `self.app.monitor.on_tp_commit(...)` inside the existing `if did_commit:` block, so bookkeeping only advances when the commit actually succeeded.

### Tests

- Extended `test_commit_offsets__did_not_commit` to assert `monitor.on_tp_commit` is not called and `_committed_offset` is unchanged when the commit fails (`did_commit=False`).
- Extended `test_commit_offsets` (happy path) to assert `monitor.on_tp_commit` **is** called and `_committed_offset` **is** updated when the commit succeeds, so both branches of the guard are covered.
- Verified the new negative-path assertions actually catch the bug: reverting the fix while keeping the new test makes it fail with `AssertionError: Expected 'on_tp_commit' to not have been called. Called 1 times.` — confirming the test is not vacuous.
- `flake8`, `black --check`, `isort --check-only` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_