### PR TITLE
Respect an explicit autodiscover list under Django

### DIFF
--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -705,8 +705,17 @@ class App(AppT, Service):
             categories = self.SCAN_CATEGORIES
         modules = set(self._discovery_modules())
         modules |= set(extra_modules)
-        for fixup in self.fixups:
-            modules |= set(fixup.autodiscover_modules())
+        # Fixup-provided autodiscovery (e.g. the Django fixup scanning every
+        # app in INSTALLED_APPS) only applies to the blanket
+        # ``autodiscover=True`` mode -- as documented on the Django fixup.
+        # When the user passes an explicit module list (or a callable),
+        # respect it and do not additionally pull in every fixup module,
+        # otherwise a Django app that set e.g.
+        # ``autodiscover=['myproj.agents']`` would still scan all of
+        # INSTALLED_APPS (including migrations/admin).  See #500.
+        if self.conf.autodiscover is True:
+            for fixup in self.fixups:
+                modules |= set(fixup.autodiscover_modules())
         if modules:
             scanner = venusian.Scanner()
             for name in modules:

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -465,6 +465,9 @@ class Test_App:
         on_worker_init.assert_called_once_with(app, signal=app.on_worker_init)
 
     def test_discover(self, *, app):
+        # With an explicit module list, fixup-provided modules (e.g. Django's
+        # INSTALLED_APPS) must NOT be pulled in -- the user's list is honored
+        # as-is.  See #500.
         app.conf.autodiscover = ["a", "b", "c"]
         app.conf.origin = "faust"
         fixup1 = Mock(name="fixup1", autospec=Fixup)
@@ -479,12 +482,32 @@ class Test_App:
                         call("a"),
                         call("b"),
                         call("c"),
-                        call("d"),
-                        call("e"),
                         call("faust"),
                     ],
                     any_order=True,
                 )
+                imported = {c.args[0] for c in import_module.call_args_list}
+                assert "d" not in imported
+                assert "e" not in imported
+                fixup1.autodiscover_modules.assert_not_called()
+
+    def test_discover__true_includes_fixup_modules(self, *, app):
+        # The blanket autodiscover=True mode DOES pull in fixup-provided
+        # modules (e.g. every app in Django's INSTALLED_APPS).
+        app.conf.autodiscover = True
+        app.conf.origin = "faust"
+        fixup1 = Mock(name="fixup1", autospec=Fixup)
+        fixup1.autodiscover_modules.return_value = ["d", "e"]
+        app.fixups = [fixup1]
+        with patch("faust.app.base.venusian"):
+            with patch("importlib.import_module") as import_module:
+                app.discover()
+
+                import_module.assert_has_calls(
+                    [call("faust"), call("d"), call("e")],
+                    any_order=True,
+                )
+                fixup1.autodiscover_modules.assert_called_once_with()
 
     def test_discover__disabled(self, *, app):
         app.conf.autodiscover = False


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://faust-streaming.github.io/faust/contributing.html).

## Description

Fixes #500.

`App.discover()` unconditionally unioned every fixup's `autodiscover_modules()` into the set of modules to scan:

```python
for fixup in self.fixups:
    modules |= set(fixup.autodiscover_modules())
```

The Django fixup's `autodiscover_modules()` returns **all of `INSTALLED_APPS`**. So an app that set an explicit list — e.g. `autodiscover=['myproj.agents']` — still had *every* installed Django app scanned, importing unrelated `migrations`/`admin` modules and frequently failing.

This contradicts the Django fixup's own documented behavior:

> If `faust.App(autodiscovery=True)`, the Django fixup will automatically autodiscover agents/tasks/web views … found in installed Django apps.

i.e. the INSTALLED_APPS scan is meant for the blanket `autodiscover=True` mode, not for an explicit list.

### Fix

Only pull in fixup-provided modules when `conf.autodiscover is True`. When the user passes an explicit list (or a callable), honor it as-is. Django itself is still set up independently via `Fixup.on_worker_init()` (which calls `django.setup()`), so this does not affect Django initialization — only which modules get scanned for `@app.agent`/task/view decorators.

### Tests

- Updated `test_discover` (explicit list): asserts the fixup's modules (`d`, `e`) are **not** imported and `fixup.autodiscover_modules` is not called.
- Added `test_discover__true_includes_fixup_modules`: with `autodiscover=True`, the fixup modules **are** scanned.
- Verified the updated test catches the bug: reverting the fix makes `d`/`e` get imported for the explicit-list case.
- `flake8` / `black --check` / `isort --check-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_