### PR TITLE
Fix #105: don't crash collecting actor tracebacks for finished coroutines

### DIFF
--- a/faust/agents/agent.py
+++ b/faust/agents/agent.py
@@ -235,7 +235,22 @@ class Agent(AgentT, Service):
         return []
 
     def actor_tracebacks(self) -> List[str]:
-        return [actor.traceback() for actor in self._actors]
+        tracebacks: List[str] = []
+        for actor in self._actors:
+            try:
+                tracebacks.append(actor.traceback())
+            except RuntimeError as exc:
+                # A coroutine/async generator that has finished naturally has
+                # no stack frame (``cr_frame``/``ag_frame`` is ``None``), and
+                # ``mode`` raises "cannot find stack of coroutine" when asked
+                # to format it.  This happens during ``wait_empty`` around
+                # shutdown and rebalances, where tracebacks are collected
+                # purely for logging -- so a missing frame must not crash the
+                # whole collection.  See issue #105.
+                tracebacks.append(
+                    f"Could not extract traceback for actor {actor!r}: {exc}"
+                )
+        return tracebacks
 
     async def _start_one(
         self,

--- a/tests/unit/agents/test_agent.py
+++ b/tests/unit/agents/test_agent.py
@@ -239,6 +239,29 @@ class Test_Agent:
         actor1.cancel.assert_called_once_with()
         actor2.cancel.assert_called_once_with()
 
+    def test_actor_tracebacks(self, *, agent):
+        actor1 = Mock(name="actor1")
+        actor1.traceback.return_value = "traceback for actor1"
+        agent._actors = [actor1]
+        assert agent.actor_tracebacks() == ["traceback for actor1"]
+
+    def test_actor_tracebacks__missing_stack(self, *, agent):
+        # A finished coroutine has no stack frame, and mode raises
+        # RuntimeError("cannot find stack of coroutine").  Collecting
+        # tracebacks (for logging around shutdown/rebalance) must not
+        # let that error escape.  See issue #105.
+        good = Mock(name="good_actor")
+        good.traceback.return_value = "traceback for good"
+        bad = Mock(name="bad_actor")
+        bad.traceback.side_effect = RuntimeError("cannot find stack of coroutine")
+        agent._actors = [good, bad]
+
+        tracebacks = agent.actor_tracebacks()
+
+        assert tracebacks[0] == "traceback for good"
+        assert "Could not extract traceback" in tracebacks[1]
+        assert "cannot find stack of coroutine" in tracebacks[1]
+
     @pytest.mark.asyncio
     async def test_on_partitions_revoked(self, *, agent):
         revoked = {TP("foo", 0)}


### PR DESCRIPTION
## What

`Agent.actor_tracebacks()` iterated every actor calling `actor.traceback()`, which delegates to `mode`'s coroutine / async-generator stack formatter. A coroutine or async generator that has **finished naturally** has no stack frame (`cr_frame` / `ag_frame` is `None`), and `mode` raises `RuntimeError('cannot find stack of coroutine')` when asked to format it.

Traceback collection runs inside `Consumer.wait_empty` around shutdown and rebalances, purely to log agent state. Because the old code built the list in one comprehension, a single finished actor aborted the whole collection — and with it a clean shutdown/rebalance.

Fixes #105.

## How

Collect tracebacks one actor at a time and catch `RuntimeError` per actor, substituting a short placeholder (`Could not extract traceback for actor <actor>: <exc>`) instead of letting it propagate. This mirrors the workaround several users adopted via a custom `Agent` subclass, but folds it into faust itself so no subclass is required.

## Test

Added `test_actor_tracebacks` and `test_actor_tracebacks__missing_stack` in `tests/unit/agents/test_agent.py`: the first confirms normal collection, the second confirms a `RuntimeError('cannot find stack of coroutine')` from one actor is swallowed into a placeholder while a sibling actor's traceback is still returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_