### PR TITLE
Fix #319: record event runtime for events acked via stream.take()

### DIFF
--- a/faust/events.py
+++ b/faust/events.py
@@ -2,7 +2,7 @@
 
 import typing
 from types import TracebackType
-from typing import Any, Awaitable, Optional, Type, Union, cast
+from typing import Any, Awaitable, Dict, Optional, Type, Union, cast
 
 from faust.types import (
     AppT,
@@ -128,6 +128,11 @@ class Event(EventT):
             self.headers = {}
 
         self.acked: bool = False
+        #: Per-sensor state captured by ``Sensor.on_stream_event_in`` and
+        #: handed back to ``on_stream_event_out`` when the event is acked.
+        #: Stored here so deferred acks (e.g. ``Stream.take``) can still
+        #: report the event runtime.  See issue #319.
+        self.sensor_state: Optional[Dict] = None
 
     async def send(
         self,

--- a/faust/sensors/base.py
+++ b/faust/sensors/base.py
@@ -182,10 +182,16 @@ class SensorDelegate(SensorDelegateT):
         self, tp: TP, offset: int, stream: StreamT, event: EventT
     ) -> Optional[Dict]:
         """Call when stream starts processing an event."""
-        return {
+        state = {
             sensor: sensor.on_stream_event_in(tp, offset, stream, event)
             for sensor in self._sensors
         }
+        # Remember the per-sensor state on the event itself so that a
+        # deferred ack (e.g. Stream.take(), which acks manually long after
+        # the main loop yielded) can still deliver it to on_stream_event_out
+        # and record the true event runtime.  See issue #319.
+        event.sensor_state = state
+        return state
 
     def on_stream_event_out(
         self, tp: TP, offset: int, stream: StreamT, event: EventT, state: Dict = None

--- a/faust/streams.py
+++ b/faust/streams.py
@@ -1268,7 +1268,13 @@ class Stream(StreamT[T_co], Service):
         message = event.message
         tp = message.tp
         offset = message.offset
-        self._on_stream_event_out(tp, offset, self, event)
+        # Forward the sensor state captured in on_stream_event_in so the
+        # event runtime is recorded even when acking is deferred (e.g. the
+        # buffered events produced by Stream.take()).  Clear it afterwards so
+        # a second ack of the same event cannot double-count.  See issue #319.
+        sensor_state = getattr(event, "sensor_state", None)
+        self._on_stream_event_out(tp, offset, self, event, sensor_state)
+        event.sensor_state = None
         if last_stream_to_ack:
             self._on_message_out(tp, offset, message)
         return last_stream_to_ack

--- a/faust/types/events.py
+++ b/faust/types/events.py
@@ -4,6 +4,7 @@ from typing import (
     Any,
     AsyncContextManager,
     Awaitable,
+    Dict,
     Generic,
     Mapping,
     Optional,
@@ -38,8 +39,9 @@ class EventT(Generic[T], AsyncContextManager):
     headers: Mapping
     message: Message
     acked: bool
+    sensor_state: Optional[Dict]
 
-    __slots__ = ("app", "key", "value", "headers", "message", "acked")
+    __slots__ = ("app", "key", "value", "headers", "message", "acked", "sensor_state")
 
     @abc.abstractmethod
     def __init__(

--- a/tests/functional/test_streams.py
+++ b/tests/functional/test_streams.py
@@ -9,6 +9,7 @@ from mode.utils.aiter import aiter, anext
 
 import faust
 from faust.exceptions import ImproperlyConfigured
+from faust.sensors import Monitor
 from faust.streams import maybe_forward
 from tests.helpers import AsyncMock
 
@@ -775,6 +776,30 @@ async def test_take(app):
             assert event.message.acked
             assert not event.message.refcount
         assert s.enable_acks is True
+
+
+@pytest.mark.skipif(
+    platform.python_implementation() == "PyPy", reason="Not yet supported on PyPy"
+)
+@pytest.mark.asyncio
+async def test_take__records_event_runtime(app):
+    # Regression test for #319: events buffered by take() are acked manually
+    # after the main loop has already yielded, so on_stream_event_out used to
+    # be called without the sensor state and no event runtime was recorded.
+    monitor = Monitor()
+    app.sensors.add(monitor)
+    async with new_stream(app) as s:
+        await s.channel.send(value=1)
+        async for value in s.take(1, within=1):
+            assert value == [1]
+            break
+        # let take()'s finally ack the buffered event
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    # on_stream_event_out ran with the captured sensor state, so a runtime
+    # was appended (would be empty before the fix).
+    assert monitor.events_runtime
 
 
 @pytest.mark.asyncio

--- a/tests/functional/test_streams.py
+++ b/tests/functional/test_streams.py
@@ -778,9 +778,6 @@ async def test_take(app):
         assert s.enable_acks is True
 
 
-@pytest.mark.skipif(
-    platform.python_implementation() == "PyPy", reason="Not yet supported on PyPy"
-)
 @pytest.mark.asyncio
 async def test_take__records_event_runtime(app):
     # Regression test for #319: events buffered by take() are acked manually

--- a/tests/unit/test_streams.py
+++ b/tests/unit/test_streams.py
@@ -210,15 +210,21 @@ class Test_Stream:
     async def test_ack(self, *, stream):
         event = Mock()
         event.ack.return_value = True
+        event.sensor_state = {"sensor": "state"}
         stream._on_stream_event_out = Mock()
         stream._on_message_out = Mock()
         assert await stream.ack(event)
+        # the sensor state captured in on_stream_event_in is forwarded so
+        # deferred acks still record the event runtime (issue #319)
         stream._on_stream_event_out.assert_called_once_with(
             event.message.tp,
             event.message.offset,
             stream,
             event,
+            {"sensor": "state"},
         )
+        # ...and cleared afterwards so a second ack can't double-count
+        assert event.sensor_state is None
         stream._on_message_out.assert_called_once_with(
             event.message.tp,
             event.message.offset,


### PR DESCRIPTION
## What

When an agent consumes a stream with `stream.take(max_, within=...)`, the event runtime metric (`events_runtime`, surfaced e.g. as Prometheus `events_runtime_ms_sum`) stayed at **zero**.

Fixes #319.

## Why

`take()` disables acking (`enable_acks = False`) and acks its buffered events **manually** in its `finally`, long after the main iteration loop yielded them. The main loop only calls `on_stream_event_out` when `do_ack` is set, so for the `take()` path the out-event is delivered by `Stream.ack()` instead.

But `Stream.ack()` called `on_stream_event_out(tp, offset, self, event)` **without** the sensor state. `Monitor.on_stream_event_out` needs that state (which carries `time_in`) to compute `time_total`; with `state=None` it does nothing, so no runtime was ever recorded for taken events.

## How

- **`SensorDelegate.on_stream_event_in`** now stashes the per-sensor state dict on the event itself (`event.sensor_state`). Both the Python (`_py_aiter`) and Cython (`_cython/streams`) iterators call this same delegate method, so the state is captured regardless of which iterator runs — no `.pyx` recompile needed.
- **`Stream.ack()`** reads `event.sensor_state`, forwards it to `on_stream_event_out`, then clears it so a second ack can't double-count.
- **`Event`** / **`EventT`** gain a `sensor_state` attribute (initialised to `None`, added to `EventT.__slots__`).

The normal (acks-enabled) path is unchanged: the main loop still fires `on_stream_event_out` with its local state and never routes through `Stream.ack()`.

## Test

Added `test_take__records_event_runtime` in `tests/functional/test_streams.py`: attaches a `Monitor`, sends a value, consumes one buffered batch via `take()`, and asserts `monitor.events_runtime` is non-empty. Verified it **fails on master** (`assert deque([])`) and passes with the fix, under both the Cython and `NO_CYTHON` stream iterators. Updated the `Stream.ack` unit test for the new forwarded/cleared `sensor_state` argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_