### PR TITLE
Fix #446: don't crash livelock detector when consumer not yet started

### DIFF
--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -80,7 +80,7 @@ from mode.utils.futures import notify
 from mode.utils.text import pluralize
 from mode.utils.times import Seconds
 
-from faust.exceptions import ProducerSendError
+from faust.exceptions import ConsumerNotStarted, ProducerSendError
 from faust.types import TP, AppT, ConsumerMessage, Message, RecordMetadata
 from faust.types.core import HeadersArg
 from faust.types.transports import (
@@ -900,7 +900,15 @@ class Consumer(Service, ConsumerT):
 
     async def verify_all_partitions_active(self) -> None:
         now = monotonic()
-        for tp in self.assignment():
+        try:
+            assignment = self.assignment()
+        except ConsumerNotStarted:
+            # The commit-livelock detector may run before the consumer
+            # thread has finished starting (observed with alternative event
+            # loops such as eventlet).  There is nothing to verify yet, so
+            # skip this cycle instead of crashing the app.  See issue #446.
+            return
+        for tp in assignment:
             await self.sleep(0)
             if not self.should_stop:
                 self.verify_event_path(now, tp)

--- a/tests/unit/transport/test_consumer.py
+++ b/tests/unit/transport/test_consumer.py
@@ -9,7 +9,7 @@ from mode.utils.futures import done_future
 
 from faust import App
 from faust.app._attached import Attachments
-from faust.exceptions import AlreadyConfiguredWarning
+from faust.exceptions import AlreadyConfiguredWarning, ConsumerNotStarted
 from faust.tables.manager import TableManager
 from faust.transport.base import Producer, Transport
 from faust.transport.conductor import Conductor
@@ -1412,6 +1412,21 @@ class Test_ThreadDelegateConsumer:
                     call(now, TP3),
                 ]
             )
+
+    @pytest.mark.asyncio
+    async def test_verify_all_partitions_active__consumer_not_started(
+        self, *, consumer
+    ):
+        # The livelock detector can run before the consumer thread has
+        # started; assignment() then raises ConsumerNotStarted.  This must
+        # be swallowed rather than crash the app.  See issue #446.
+        consumer.assignment = Mock(name="assignment", side_effect=ConsumerNotStarted())
+        consumer.verify_event_path = Mock(name="verify_event_path")
+
+        with patch("faust.transport.consumer.monotonic"):
+            await consumer.verify_all_partitions_active()
+
+        consumer.verify_event_path.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_verify_all_partitions_active__bail_on_sleep(self, *, consumer):


### PR DESCRIPTION
## What

The commit-livelock detector (`_commit_livelock_detector`, a background `Service.task`) periodically calls `verify_all_partitions_active()`, which iterates `self.assignment()`. If the consumer **thread** hasn't finished starting yet, `assignment()` → `_ensure_consumer()` raises:

```
faust.exceptions.ConsumerNotStarted: Consumer thread not yet started
```

That unhandled exception crashes the app. It was reported with the eventlet event loop (`-L eventlet`), where thread startup timing differs, but it's a general startup race in the detector.

Fixes #446.

## How

`verify_all_partitions_active()` now catches `ConsumerNotStarted` around the `assignment()` call and returns early — there is simply nothing to verify until the consumer thread is up, so the detector skips that cycle and tries again on the next tick instead of propagating the exception.

## Test

Added `test_verify_all_partitions_active__consumer_not_started` in `tests/unit/transport/test_consumer.py`: makes `assignment()` raise `ConsumerNotStarted` and asserts `verify_all_partitions_active()` returns without raising and without verifying any partition. Full `tests/unit/transport/test_consumer.py` passes (114 passed, 2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_