### PR TITLE
docs: correct stale dependency and version references

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ globals().update(conf.build_config(
     canonical_url='https://faust-streaming.github.io/faust',
     webdomain='',
     github_project='faust-streaming/faust',
-    copyright='2017-2020, 2021-2022 Community',
+    copyright='2017-2020, 2021-2026 Community',
     html_logo='images/logo.png',
     html_favicon='images/favicon.ico',
     html_prepend_sidebars=[],

--- a/docs/copyright.rst
+++ b/docs/copyright.rst
@@ -7,6 +7,8 @@ Copyright
 
 Copyright |copy| 2017-2020, Robinhood Markets, Inc.
 
+Copyright |copy| 2021-2026, the faust-streaming project.
+
 All rights reserved.  This material may be copied or distributed only
 subject to the terms and conditions set forth in the `Creative Commons
 Attribution-ShareAlike 4.0 International`

--- a/docs/includes/installation.txt
+++ b/docs/includes/installation.txt
@@ -46,6 +46,13 @@ Caching
 :``faust[redis]``:
     for using `Redis_` as a simple caching backend (Memcached-style).
 
+Transports
+~~~~~~~~~~
+
+:``faust[ckafka]``:
+    for using the :pypi:`confluent-kafka` client through the ``confluent://``
+    transport.
+
 Codecs
 ~~~~~~
 

--- a/docs/includes/installation.txt
+++ b/docs/includes/installation.txt
@@ -37,6 +37,10 @@ Stores
 
     **Recommended in production.**
 
+:``faust[rocksdict]``:
+    for storing Faust table state in `RocksDB`_ through the
+    :pypi:`rocksdict` bindings.
+
 
 .. _`RocksDB`: http://rocksdb.org
 
@@ -73,6 +77,12 @@ Sensors
 
 :``faust[statsd]``:
     for using the Statsd Faust monitor.
+
+:``faust[prometheus]``:
+    for using the Prometheus Faust monitor.
+
+:``faust[sentry]``:
+    for reporting worker errors to Sentry via :pypi:`sentry-sdk`.
 
 Event Loops
 ~~~~~~~~~~~

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -151,11 +151,11 @@ What do I need?
 ==================
 
 .. sidebar:: Version Requirements
-    :subtitle: Faust version 1.0 runs on
+    :subtitle: Faust runs on
 
     **Core**
 
-    - Python 3.8 or later.
+    - Python 3.10 or later.
     - Kafka 0.10.1 or later.
 
     **Extensions**
@@ -176,7 +176,7 @@ Extensions
 +--------------+-------------+--------------------------------------------------+
 | ``rocksdb``  | 5.0         | ``pip install faust-streaming[rocksdb]``         |
 +--------------+-------------+--------------------------------------------------+
-| ``redis``    | aredis 1.1  | ``pip install faust-streaming[redis]``           |
+| ``redis``    | redis-py    | ``pip install faust-streaming[redis]``           |
 +--------------+-------------+--------------------------------------------------+
 | ``datadog``  | 0.20.0      | ``pip install faust-streaming[datadog]``         |
 +--------------+-------------+--------------------------------------------------+

--- a/docs/userguide/application.rst
+++ b/docs/userguide/application.rst
@@ -78,7 +78,7 @@ the driver that you want to use (it can also be the fully qualified
 path to a Python class).
 
 The storage driver decides how to keep distributed tables locally, and
-Faust version 1.0 supports two options:
+Faust supports two options:
 
 +----------------+-----------------------------------------------+
 | ``rocksdb://`` | `RocksDB`_ an embedded database (production)  |


### PR DESCRIPTION
## Description

Fixes stale references in the user-facing docs surfaced while auditing the
GitHub Pages docs for the 0.12 line. All changes are documentation-only.

**Correctness fixes**
- **`redis` extra listed the deprecated `aredis`.** The extra is backed by
  `redis-py` now (since #635), so the Extensions table said the wrong library.
- **Python-version contradiction in "What do I need?".** The sidebar claimed
  *Python 3.8 or later* while the prose immediately below already states the
  real minimum, *Python 3.10 or later*. Aligned the sidebar to 3.10.
- **Dropped two stale "Faust version 1.0" self-references** (the requirements
  sidebar subtitle and the storage-driver section in the App user guide).

**Completeness / freshness**
- **Documented previously-undocumented install bundles:** `faust[ckafka]`
  (confluent-kafka / `confluent://` transport), `faust[rocksdict]` (RocksDB via
  the `rocksdict` bindings), and `faust[prometheus]` / `faust[sentry]` sensors.
- **Refreshed the docs copyright** to 2026 and noted the faust-streaming
  project's continued maintenance (`conf.py` + `copyright.rst`).

The grid-table column widths are preserved (verified against the `+---+`
separators), and `docs/conf.py` byte-compiles.

### Scope notes
- Every documented bundle was checked against `setup.py`'s `BUNDLES` and
  `requirements/extras/`. **`aerospike` is intentionally omitted** — it ships a
  requirements file but is not in `BUNDLES`, so `faust[aerospike]` is not an
  installable extra.
- The frozen `history/` changelogs and the auto-generated `reference/` API docs
  were intentionally left untouched — they document past releases.
- `opentracing` / `opentelemetry` extras are **not** documented here because
  those extras don't exist on `master` yet (their PRs #685/#686/#688 are still
  open); documenting them now would be inaccurate. They can be added when those
  land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)