### PR TITLE
ci: build sdist with python -m build for a PEP 625-compliant filename

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -211,9 +211,13 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
       - name: Build sdist
+        # Use `python -m build`, not the deprecated `setup.py sdist`, so the
+        # sdist is named with the normalized project name
+        # (`faust_streaming-*.tar.gz`).  PyPI enforces PEP 625 and rejects the
+        # legacy hyphenated `faust-streaming-*.tar.gz`.
         run: >
-          pip3 install pkgconfig cython --upgrade &&
-          python3 setup.py sdist
+          pip3 install build pkgconfig cython --upgrade &&
+          python3 -m build --sdist --outdir dist
       - uses: actions/upload-artifact@v4
         name: Upload build artifacts
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,9 @@ Changes = "https://github.com/faust-streaming/faust/releases"
 
 [build-system]
 requires = [
-    "setuptools>=30.3.0",
+    # setuptools >= 69 normalizes the sdist filename per PEP 625
+    # (faust_streaming-*.tar.gz), which PyPI now requires.
+    "setuptools>=69",
     "setuptools_scm[toml]",
     "wheel",
     "cython>=0.29; implementation_name == 'cpython'",


### PR DESCRIPTION
## Description

The v0.12.0 publish job failed uploading the sdist to PyPI
([run](https://github.com/faust-streaming/faust/actions/runs/29698765482/job/88224636648)):

```
400 Filename 'faust-streaming-0.12.0.tar.gz' is invalid,
    should be 'faust_streaming-0.12.0.tar.gz'.
```

All wheels uploaded fine (`faust_streaming-0.12.0-*.whl`, 200 OK) — only the
**sdist** was rejected.

### Root cause
The `build_sdist` job built the tarball with the deprecated
`python3 setup.py sdist` under an old `setuptools>=30.3.0` floor, which emits
the **legacy hyphenated** distribution filename `faust-streaming-0.12.0.tar.gz`.
PyPI now enforces [PEP 625](https://peps.python.org/pep-0625/) and requires the
**normalized** name (underscores): `faust_streaming-0.12.0.tar.gz`.

### Fix
- Build the sdist with `python -m build --sdist` instead of
  `setup.py sdist`.
- Raise the `[build-system]` setuptools floor to `>=69`, the version that
  normalizes sdist filenames per PEP 625.

The wheels were unaffected (cibuildwheel already emits the normalized name), so
no wheel-side change is needed. The publish step already sets
`skip-existing: true`, so a re-run will skip the already-uploaded 0.12.0 wheels
and upload only the (now correctly-named) sdist.

### Verification
Local `python -m build --sdist` now produces:

```
faust_streaming-<version>.tar.gz   ✅  (was faust-streaming-<version>.tar.gz)
```

### Note on recovering the v0.12.0 sdist
v0.12.0's wheels are already on PyPI; only its sdist is missing. Because a
workflow re-run uses the workflow file *at the tagged commit* (still the old
one), the cleanest way to get a correct sdist published is to cut **v0.12.1**
with this fix (wheels + sdist rebuild fresh; `skip-existing` handles any
overlap). Alternatively, build the sdist locally with `python -m build --sdist`
and `twine upload` it to the existing 0.12.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_