### PR TITLE
docs: prepare v0.12.1 release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ https://github.com/faust-streaming/faust/releases.  The v0.12.0 entry below
 resumes the Keep a Changelog format.
 -->
 
+## [v0.12.1](https://github.com/faust-streaming/faust/releases/tag/v0.12.1) - 2026-07-19
+
+[Compare with v0.12.0](https://github.com/faust-streaming/faust/compare/v0.12.0...v0.12.1)
+
+Packaging-only patch release. v0.12.0's wheels published to PyPI, but its source
+distribution was rejected under [PEP 625](https://peps.python.org/pep-0625/);
+this release fixes the sdist filename so the full set of artifacts publishes.
+
+### Fixed
+- Build the source distribution with `python -m build` and a PEP 625-compliant
+  (normalized) filename — `faust_streaming-<version>.tar.gz` instead of the
+  legacy `faust-streaming-<version>.tar.gz` that PyPI now rejects (#712).
+
 ## [v0.12.0](https://github.com/faust-streaming/faust/releases/tag/v0.12.0) - 2026-07-19
 
 [Compare with v0.11.3](https://github.com/faust-streaming/faust/compare/v0.11.3...v0.12.0)

--- a/RELEASE_NOTES_v0.12.1.md
+++ b/RELEASE_NOTES_v0.12.1.md
@@ -1,0 +1,33 @@
+# faust-streaming 0.12.1
+
+Packaging-only patch release, dated 2026-07-19.
+
+## Why this release
+
+v0.12.0's **wheels** published to PyPI successfully, but its **source
+distribution** upload was rejected:
+
+```
+400 Filename 'faust-streaming-0.12.0.tar.gz' is invalid,
+    should be 'faust_streaming-0.12.0.tar.gz'.
+```
+
+PyPI now enforces [PEP 625](https://peps.python.org/pep-0625/), which requires
+the sdist filename to use the *normalized* project name (underscores). The
+release job built the sdist with the deprecated `setup.py sdist` under an old
+setuptools, producing the legacy hyphenated name.
+
+## Fixed
+
+- Build the source distribution with `python -m build` and raise the
+  `[build-system]` setuptools floor to `>=69`, so the sdist is named
+  `faust_streaming-<version>.tar.gz` and PyPI accepts it (#712).
+
+## Upgrade notes
+
+There are **no code changes** in this release — it is functionally identical to
+v0.12.0. It exists only so the source distribution is available on PyPI (e.g.
+for consumers that build from sdist). If you install from wheels, v0.12.0 and
+v0.12.1 are equivalent.
+
+**Full changelog:** https://github.com/faust-streaming/faust/compare/v0.12.0...v0.12.1


### PR DESCRIPTION
## Description

Release-prep docs for **v0.12.1**, a **packaging-only patch**. v0.12.0's wheels
published to PyPI, but its source distribution was rejected under PEP 625
(hyphenated `faust-streaming-0.12.0.tar.gz` vs the required
`faust_streaming-0.12.0.tar.gz`). The code fix is **#712**; this PR is the notes.

- **`CHANGELOG.md`** — new `## [v0.12.1]` section above v0.12.0, with a
  `v0.12.0...v0.12.1` compare link, documenting the sdist fix (#712).
- **`RELEASE_NOTES_v0.12.1.md`** — standalone GitHub release notes noting there
  are no functional changes (wheels-only installers are unaffected).

### On "versioning files" and the Pages docs
There are **no version files to bump** — versioning is setuptools_scm-driven
(the git tag *is* the version), confirmed by grep (no `VERSION` file, no
hardcoded package version). The **GitHub Pages docs** reflect 0.12.1 with no
hardcoding:
- the changelog page is `docs/changelog.rst` → `.. mdinclude:: ../CHANGELOG.md`,
  so it renders the new v0.12.1 entry automatically;
- `docs/conf.py` derives the docs version from `faust.__version__`
  (setuptools_scm / tag), so the version banner updates to `0.12` on the next
  Pages build and the full `release` shows `0.12.1`.

### Release order (for the maintainer)
1. Merge **#712** (the actual sdist/PEP 625 fix) — required for the sdist to
   publish.
2. Merge this PR.
3. Tag **v0.12.1** on master and create the GitHub release — the publish job
   rebuilds wheels + a correctly-named sdist (the publish step already sets
   `skip-existing: true`, so any 0.12.0 overlap is skipped).
4. Paste `RELEASE_NOTES_v0.12.1.md` into the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_