### PR TITLE
ci: verify support for Apache Kafka 4.0 in the integration matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -108,7 +108,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kafka-version: ['3.8.1']
+        # Test against both a 3.x broker and Kafka 4.x (KRaft-only, released
+        # 2025).  The `KAFKA_CONTROLLER_QUORUM_VOTERS` static-voter config below
+        # works for both.
+        kafka-version: ['3.8.1', '4.0.0']
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

Adds **Apache Kafka 4.0** to faust's live-broker integration test matrix so the
project is continuously verified against a 4.x broker (KRaft-only, released
2025) alongside 3.x:

```yaml
kafka-version: ['3.8.1', '4.0.0']
```

The integration job's existing `KAFKA_CONTROLLER_QUORUM_VOTERS` static-voter
config works unchanged on 4.0 (static voters are still supported), so only the
matrix entry is needed.

## Verification (against a real Kafka 4.0.0 broker)

I ran the full `tests/integration/broker` suite against a locally-run
**apache-kafka 4.0.0** broker (KRaft, `metadata.version 4.0-IV3`) — all pass:

```
test_offset_commit.py::test_does_not_commit_past_inflight_message  PASSED
test_offset_commit.py::test_commits_contiguous_acks                PASSED
test_smoke.py::test_aiokafka_roundtrip                             PASSED
test_smoke.py::test_confluent_roundtrip                            PASSED
4 passed
```

Both transport drivers (aiokafka and confluent-kafka) round-trip correctly, and
the offset-commit regression tests pass. **No faust code changes are required
for Kafka 4 support** — this PR turns "it happens to work" into a tested
guarantee.

## Notes
- The integration job is advisory (`continue-on-error: true`, not in the
  required `check` gate), so a flaky broker leg never blocks merges.
- Kafka 4.0 requires Java 17+ on the broker side; that's the container's
  concern (the `apache/kafka:4.0.0` image), not faust's.
- Depends on the offset-commit tests from #707 for the two `test_offset_commit`
  cases; the aiokafka/confluent smoke tests (already on master via #706) also
  exercise 4.0 on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_