### PR TITLE
test: re-enable recoverable skipped tests (+ fix latent LazySpan bug)

### DIFF
--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -629,7 +629,14 @@ class AIOKafkaConsumerThread(ConsumerThread):
                 def finish(self) -> None:
                     consumer._span_finish(span)
 
-            span._real_finish, span.finish = span.finish, LazySpan.finish
+            # Bind the replacement to ``span`` -- assigning the raw
+            # ``LazySpan.finish`` function leaves it unbound, so the later
+            # ``span.finish()`` call raises "missing 1 required positional
+            # argument: 'self'".
+            span._real_finish, span.finish = (
+                span.finish,
+                LazySpan.finish.__get__(span),
+            )
 
     def _span_finish(self, span: opentracing.Span) -> None:
         assert self._consumer is not None

--- a/tests/unit/agents/test_agent.py
+++ b/tests/unit/agents/test_agent.py
@@ -469,7 +469,6 @@ class Test_Agent:
             await agent._execute_actor(coro, Mock(name="aref", autospec=Actor))
         coro.assert_awaited()
 
-    @pytest.mark.skip(reason="Fix is TBD")
     @pytest.mark.asyncio
     async def test_execute_actor__cancelled_running(self, *, agent):
         agent._on_error = AsyncMock(name="on_error")

--- a/tests/unit/transport/drivers/test_aiokafka.py
+++ b/tests/unit/transport/drivers/test_aiokafka.py
@@ -437,13 +437,17 @@ class Test_Log_Slow_Processing(Test_verify_event_path_base):
         )
 
 
-@pytest.mark.skip("Needs fixing")
 class Test_VEP_no_fetch_since_start(Test_verify_event_path_base):
     def test_just_started(self, *, cthread, now, tp, logger):
         self._set_started(now - 2.0)
         assert cthread.verify_event_path(now, tp) is None
         logger.error.assert_not_called()
 
+    @pytest.mark.skip(
+        reason="verify_event_path no longer emits the fetch-timeout "
+        "error() under this condition; predates that behaviour change and "
+        "needs re-deriving against the current driver"
+    )
     def test_timed_out(self, *, cthread, now, tp, logger):
         self._set_started(
             now - cthread.tp_fetch_request_timeout_secs * 2,
@@ -456,7 +460,6 @@ class Test_VEP_no_fetch_since_start(Test_verify_event_path_base):
         )
 
 
-@pytest.mark.skip("Needs fixing")
 class Test_VEP_no_response_since_start(Test_verify_event_path_base):
     def test_just_started(self, *, cthread, _consumer, now, tp, logger):
         self._set_last_request(now - 5.0)
@@ -464,6 +467,11 @@ class Test_VEP_no_response_since_start(Test_verify_event_path_base):
         assert cthread.verify_event_path(now, tp) is None
         logger.error.assert_not_called()
 
+    @pytest.mark.skip(
+        reason="verify_event_path no longer emits the fetch-timeout "
+        "error() under this condition; predates that behaviour change and "
+        "needs re-deriving against the current driver"
+    )
     def test_timed_out(self, *, cthread, _consumer, now, tp, logger):
         assert cthread.verify_event_path(now, tp) is None
         self._set_last_request(now - 5.0)
@@ -501,7 +509,6 @@ class Test_VEP_no_recent_fetch(Test_verify_event_path_base):
         )
 
 
-@pytest.mark.skip("Needs fixing")
 class Test_VEP_no_recent_response(Test_verify_event_path_base):
     def test_recent_response(self, *, cthread, now, tp, logger):
         self._set_last_request(now - 10.0)
@@ -509,6 +516,11 @@ class Test_VEP_no_recent_response(Test_verify_event_path_base):
         assert cthread.verify_event_path(now, tp) is None
         logger.error.assert_not_called()
 
+    @pytest.mark.skip(
+        reason="verify_event_path no longer emits the fetch-timeout "
+        "error() under this condition; predates that behaviour change and "
+        "needs re-deriving against the current driver"
+    )
     def test_timed_out(self, *, cthread, now, tp, logger):
         self._set_last_request(now - 10.0)
         self._set_last_response(now - cthread.tp_fetch_response_timeout_secs * 2)
@@ -608,7 +620,6 @@ class Test_VEP_stream_idle_highwater_same_has_acks_everything_OK(
         logger.error.assert_not_called()
 
 
-@pytest.mark.skip("Needs fixing")
 class Test_VEP_stream_idle_highwater_no_inbound(Test_verify_event_path_base):
     highwater = 20
     committed_offset = 10
@@ -630,13 +641,13 @@ class Test_VEP_stream_idle_highwater_no_inbound(Test_verify_event_path_base):
         expected_message = cthread._make_slow_processing_error(
             mod.SLOW_PROCESSING_STREAM_IDLE_SINCE_START,
             [mod.SLOW_PROCESSING_CAUSE_STREAM, mod.SLOW_PROCESSING_CAUSE_AGENT],
+            "stream_processing_timeout",
+            app.conf.stream_processing_timeout,
         )
         logger.error.assert_called_once_with(
             expected_message,
             tp,
             ANY,
-            setting="stream_processing_timeout",
-            current_value=app.conf.stream_processing_timeout,
         )
 
     def test_has_inbound(self, *, app, cthread, now, tp, logger):
@@ -658,13 +669,13 @@ class Test_VEP_stream_idle_highwater_no_inbound(Test_verify_event_path_base):
         expected_message = cthread._make_slow_processing_error(
             mod.SLOW_PROCESSING_STREAM_IDLE,
             [mod.SLOW_PROCESSING_CAUSE_STREAM, mod.SLOW_PROCESSING_CAUSE_AGENT],
+            "stream_processing_timeout",
+            app.conf.stream_processing_timeout,
         )
         logger.error.assert_called_once_with(
             expected_message,
             tp,
             ANY,
-            setting="stream_processing_timeout",
-            current_value=app.conf.stream_processing_timeout,
         )
 
 
@@ -907,7 +918,6 @@ class Test_AIOKafkaConsumerThread(AIOKafkaConsumerThreadFixtures):
     def test_trace_category(self, *, cthread, app):
         assert cthread.trace_category == f"{app.conf.name}-_aiokafka"
 
-    @pytest.mark.skip("Needs fixing")
     def test_transform_span_lazy(self, *, cthread, app, tracer):
         cthread._consumer = Mock(name="_consumer")
         cthread._consumer._coordinator.generation = -1
@@ -920,7 +930,6 @@ class Test_AIOKafkaConsumerThread(AIOKafkaConsumerThreadFixtures):
         cthread.on_generation_id_known()
         assert not pending
 
-    @pytest.mark.skip("Needs fixing")
     def test_transform_span_flush_spans(self, *, cthread, app, tracer):
         cthread._consumer = Mock(name="_consumer")
         cthread._consumer._coordinator.generation = -1
@@ -939,7 +948,6 @@ class Test_AIOKafkaConsumerThread(AIOKafkaConsumerThreadFixtures):
 
         assert cthread._on_span_cancelled_early(span) is None
 
-    @pytest.mark.skip("Needs fixing")
     def test_transform_span_lazy_no_consumer(self, *, cthread, app, tracer):
         cthread._consumer = Mock(name="_consumer")
         cthread._consumer._coordinator.generation = -1
@@ -953,7 +961,6 @@ class Test_AIOKafkaConsumerThread(AIOKafkaConsumerThreadFixtures):
             span = pending.popleft()
             cthread._on_span_generation_known(span)
 
-    @pytest.mark.skip("Needs fixing")
     def test_transform_span_eager(self, *, cthread, app, tracer):
         cthread._consumer = Mock(name="_consumer")
         cthread._consumer._coordinator.generation = 10
@@ -1048,8 +1055,11 @@ class Test_AIOKafkaConsumerThread(AIOKafkaConsumerThreadFixtures):
         with self.assert_calls_thread(cthread, _consumer, cthread._commit, offsets):
             await cthread.commit(offsets)
 
-    @pytest.mark.skip("Needs fixing")
     @pytest.mark.asyncio
+    @pytest.mark.skip(
+        reason="stale mock: _commit no longer forwards offsets to the "
+        "wrapped AIOKafkaConsumer.commit in this harness; needs a mock refresh"
+    )
     async def test__commit(self, *, cthread, _consumer):
         offsets = {TP1: 1001}
         cthread._consumer = _consumer
@@ -1059,15 +1069,17 @@ class Test_AIOKafkaConsumerThread(AIOKafkaConsumerThreadFixtures):
             {TP1: OffsetAndMetadata(1001, "")},
         )
 
-    @pytest.mark.skip("Needs fixing")
     @pytest.mark.asyncio
     async def test__commit__already_rebalancing(self, *, cthread, _consumer):
         cthread._consumer = _consumer
         _consumer.commit.side_effect = CommitFailedError("already rebalanced")
         assert not (await cthread._commit({TP1: 1001}))
 
-    @pytest.mark.skip("Needs fixing")
     @pytest.mark.asyncio
+    @pytest.mark.skip(
+        reason="stale mock: _commit no longer forwards offsets to the "
+        "wrapped AIOKafkaConsumer.commit in this harness; needs a mock refresh"
+    )
     async def test__commit__CommitFailedError(self, *, cthread, _consumer):
         cthread._consumer = _consumer
         exc = _consumer.commit.side_effect = CommitFailedError("xx")
@@ -1077,8 +1089,11 @@ class Test_AIOKafkaConsumerThread(AIOKafkaConsumerThreadFixtures):
         cthread.crash.assert_called_once_with(exc)
         cthread.supervisor.wakeup.assert_called_once()
 
-    @pytest.mark.skip("Needs fixing")
     @pytest.mark.asyncio
+    @pytest.mark.skip(
+        reason="stale mock: _commit no longer forwards offsets to the "
+        "wrapped AIOKafkaConsumer.commit in this harness; needs a mock refresh"
+    )
     async def test__commit__IllegalStateError(self, *, cthread, _consumer):
         cthread._consumer = _consumer
         cthread.assignment = Mock()


### PR DESCRIPTION
## Description

Follow-up to #716. Sweeps the suite's 20 legacy unconditional `@pytest.mark.skip("Needs fixing"/"Fix is TBD")` tests, re-enabling every one that can be made green and **fixing a real bug** a skip was hiding. Stacked on `claude/pypy-agen-cleanup` (#716) — retarget to `master` once that merges.

### Re-enabled (7 tests)

- **Real bug fix — `faust/transport/drivers/aiokafka.py`:** `_transform_span_lazy` assigned the raw, **unbound** `LazySpan.finish` to `span.finish`, so the later `span.finish()` raised `TypeError: finish() missing 1 required positional argument: 'self'`. Lazy spans are used whenever tracing is enabled, so this was a latent crash — the four skipped `test_transform_span_*` tests were masking it. Bound the method to the span; **4 tests re-enabled.**
- **`test_aiokafka.py` stream-idle VEP (2):** `_make_slow_processing_error` grew `setting`/`current_value` params and now bakes the explanation into the message, so `log.error` no longer gets those as kwargs. Updated the two stale expectations.
- **`test_agent.py::test_execute_actor__cancelled_running` (1):** "Fix is TBD" — passes as-is now (skip rot).

### Attempted, still skipped — but with precise reasons (was "Needs fixing")

- **`test_aiokafka.py`** fetch-timeout VEP asserts ×3 — `verify_event_path` no longer emits the error() under those conditions (driver behaviour drift); `_commit` mock tests ×3 — offsets no longer flow to the wrapped `AIOKafkaConsumer.commit` in that harness. Both need real test re-derivation.

### Attempted, left as-is (need infra / dependency-API work)

Documented here rather than re-skipped in code:

| Test(s) | Why it can't just be re-enabled |
|---|---|
| `test_cache.py` redis scheme (2) | Attempt a live Redis connection; redis-py removed `StrictRedis` |
| `test_rocksdb.py::test_open_rocksdict` | `rocksdict`'s `Options()` no longer takes constructor args |
| `test_consumer.py` TransactionManager (2) | `stop_transaction` call-count / expected-calls drift |
| `test_base.py::test_compat_option` | CLI compat-option callback path changed |
| `test_consistency.py` | Module import fails on current aiokafka (`GroupCoordinatorRequest_v0` removed); this dir isn't in the CI suite |

### Verification

`tests/unit/transport` + `tests/unit/agents/test_agent.py` — **598 passed, 16 skipped, 0 failed** on CPython; flake8/black/isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_