### PR TITLE
test(consumer): fix TransactionManager stop/start-transaction assertions

### DIFF
--- a/tests/unit/transport/test_consumer.py
+++ b/tests/unit/transport/test_consumer.py
@@ -196,43 +196,24 @@ class TestTransactionManager:
 
         await manager.on_rebalance(set(), set(), set())
 
-    @pytest.mark.skip("Needs fixing")
     @pytest.mark.asyncio
     async def test__stop_transactions(self, *, manager, producer):
         tids = ["0-0", "1-0"]
         manager._start_new_producer = AsyncMock()
         await manager._stop_transactions(tids)
-        producer.stop_transaction.assert_called()
-        producer.stop_transaction.assert_called_once_with(
-            [
-                # The problem is that some reason calls with extra
-                # (commented out) garbage are being included
-                # call.shortlabel.__bool__(),
-                # call.shortlabel._str__(),
-                call("0-0"),
-                # call.shortlabel.__bool__(),
-                # call.shortlabel._str__(),
-                call("1-0"),
-            ]
+        assert producer.stop_transaction.call_count == 2
+        producer.stop_transaction.assert_has_calls(
+            [call("0-0"), call("1-0")], any_order=True
         )
 
-    @pytest.mark.skip("Needs fixing")
     @pytest.mark.asyncio
     async def test_start_transactions(self, *, manager, producer):
         tids = ["0-0", "1-0"]
         manager._start_new_producer = AsyncMock()
         await manager._start_transactions(tids)
+        assert producer.maybe_begin_transaction.call_count == 2
         producer.maybe_begin_transaction.assert_has_calls(
-            [
-                # The problem is that some reason calls with extra
-                # (commented out) garbage are being included
-                # call.shortlabel.__bool__(),
-                # call.shortlabel._str__(),
-                call("0-0"),
-                # call.shortlabel.__bool__(),
-                # call.shortlabel._str__(),
-                call("1-0"),
-            ]
+            [call("0-0"), call("1-0")], any_order=True
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Re-enables `TestTransactionManager::test__stop_transactions` and `test_start_transactions`, skipped *"Needs fixing"*.

Both used `assert_called_once_with([call("0-0"), call("1-0")])` — which asserts a **single** producer call whose only argument is a list of `Call` objects. That's not what the code does: `_stop_transactions` / `_start_transactions` drive the producer **once per transaction id** (`stop_transaction` / `maybe_begin_transaction`, each with a single string arg), so for two ids there are two calls (the original even had commented-out notes about "extra garbage" calls it couldn't reconcile).

**Fix (test-only):** assert it faithfully — `assert_has_calls([call("0-0"), call("1-0")], any_order=True)` plus `call_count == 2`. Ordering isn't asserted because the ids come from a set and `traced_from_parent_span` interleaves `shortlabel` mock accesses between the two real calls. Only the Kafka producer is mocked; the manager logic runs for real.

## Verification
`tests/unit/transport/test_consumer.py` → **115 passed**; flake8/black/isort clean. Produced under adversarial faithfulness review (confirmed the old assertion was genuinely broken and the new one reflects real behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_