### PR TITLE
redis cache: re-enable scheme/not-installed tests + fix not-installed guard

### DIFF
--- a/faust/web/cache/backends/redis.py
+++ b/faust/web/cache/backends/redis.py
@@ -16,12 +16,15 @@ from . import base
 
 try:
     import redis
-    import redis.asyncio as aredis
     import redis.exceptions
 
     redis.client.Redis
 except ImportError:  # pragma: no cover
-    aredis = None  # noqa
+    # ``on_start`` (and the module-level ``if redis is None`` guards) key off
+    # ``redis`` being ``None`` when the library is missing.  The name must be
+    # bound to ``None`` here -- otherwise it stays unbound and the guard below
+    # raises ``NameError`` instead of the intended ``ImproperlyConfigured``.
+    redis = None  # noqa
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from redis import StrictRedis as _RedisClientT

--- a/tests/functional/web/test_cache.py
+++ b/tests/functional/web/test_cache.py
@@ -1,7 +1,6 @@
 from itertools import count
 
 import pytest
-import redis.asyncio as aredis
 
 import faust
 from faust.exceptions import ImproperlyConfigured
@@ -332,14 +331,18 @@ async def test_redis__using_starting_(app, mocked_redis):
 
 
 @pytest.fixture()
-def no_aredis(monkeypatch):
-    monkeypatch.setattr("faust.web.cache.backends.redis.aredis", None)
+def no_redis(monkeypatch):
+    # The backend's ``on_start`` guards on the ``redis`` module being
+    # importable (``if redis is None``); when the library is missing both
+    # ``redis`` and ``redis.asyncio``/``aredis`` are unavailable.  Patching
+    # the ``redis`` name to ``None`` faithfully simulates the library not
+    # being installed and must raise before any socket is opened.
+    monkeypatch.setattr("faust.web.cache.backends.redis.redis", None)
 
 
-@pytest.mark.skip(reason="Needs fixing")
 @pytest.mark.asyncio
 @pytest.mark.app(cache="redis://localhost:6079")
-async def test_redis__aredis_is_not_installed(*, app, no_aredis):
+async def test_redis__aredis_is_not_installed(*, app, no_redis):
     cache = app.cache
     with pytest.raises(ImproperlyConfigured):
         async with cache:
@@ -446,7 +449,6 @@ def bp(app):
     blueprint.register(app, url_prefix="/test/")
 
 
-@pytest.mark.skip(reason="Needs fixing")
 class Test_RedisScheme:
     def test_single_client(self, app):
         url = "redis://123.123.123.123:3636//1"
@@ -455,22 +457,40 @@ class Test_RedisScheme:
         backend = Backend(app, url=url)
         assert isinstance(backend, redis.CacheBackend)
         client = backend._new_client()
-        assert isinstance(client, redis.StrictRedis)
+        # The single-node scheme maps to redis.StrictRedis, which under
+        # redis-py 8.x is the concrete redis.client.Redis class.  Creating
+        # the client does not open a socket (redis-py connects lazily).
+        single_node_client = backend._client_by_scheme[
+            redis.RedisScheme.SINGLE_NODE.value
+        ]
+        assert single_node_client is redis.redis.StrictRedis
+        assert isinstance(client, single_node_client)
+        assert isinstance(client, redis.redis.StrictRedis)
         pool = client.connection_pool
         assert pool.connection_kwargs["host"] == backend.url.host
         assert pool.connection_kwargs["port"] == backend.url.port
         assert pool.connection_kwargs["db"] == 1
 
-    def test_cluster_client(self, app):
+    def test_cluster_client(self, app, monkeypatch):
+        # A real RedisCluster client connects to the cluster on construction,
+        # so stand in the (external) cluster class with a mock -- mirroring the
+        # ``mocked_redis`` fixture which patches ``redis.StrictRedis``.
+        cluster_cls = Mock(name="RedisCluster")
+        monkeypatch.setattr("redis.RedisCluster", cluster_cls)
+
         url = "rediscluster://123.123.123.123:3636//1"
         Backend = backends.by_url(url)
         assert Backend is redis.CacheBackend
         backend = Backend(app, url=url)
         assert isinstance(backend, redis.CacheBackend)
+        # The cluster scheme maps to redis.RedisCluster.
+        assert backend._client_by_scheme[redis.RedisScheme.CLUSTER.value] is cluster_cls
         client = backend._new_client()
-        assert isinstance(client, aredis.RedisCluster)
-        pool = client.connection_pool
-        assert {
-            "host": backend.url.host,
-            "port": 3636,
-        } in pool.nodes.startup_nodes
+        assert client is cluster_cls.return_value
+        cluster_cls.assert_called_once()
+        _, kwargs = cluster_cls.call_args
+        assert kwargs["host"] == backend.url.host
+        assert kwargs["port"] == backend.url.port
+        # Redis Cluster does not accept a ``db`` argument, so the backend
+        # must strip it (see CacheBackend._as_cluster_kwargs).
+        assert "db" not in kwargs

--- a/tests/functional/web/test_cache.py
+++ b/tests/functional/web/test_cache.py
@@ -333,16 +333,15 @@ async def test_redis__using_starting_(app, mocked_redis):
 @pytest.fixture()
 def no_redis(monkeypatch):
     # The backend's ``on_start`` guards on the ``redis`` module being
-    # importable (``if redis is None``); when the library is missing both
-    # ``redis`` and ``redis.asyncio``/``aredis`` are unavailable.  Patching
-    # the ``redis`` name to ``None`` faithfully simulates the library not
-    # being installed and must raise before any socket is opened.
+    # importable (``if redis is None``).  Patching the ``redis`` name to
+    # ``None`` faithfully simulates the library not being installed and must
+    # raise before any socket is opened.
     monkeypatch.setattr("faust.web.cache.backends.redis.redis", None)
 
 
 @pytest.mark.asyncio
 @pytest.mark.app(cache="redis://localhost:6079")
-async def test_redis__aredis_is_not_installed(*, app, no_redis):
+async def test_redis__is_not_installed(*, app, no_redis):
     cache = app.cache
     with pytest.raises(ImproperlyConfigured):
         async with cache:


### PR DESCRIPTION
## Description

Re-enables the skipped redis cache tests **and** fixes the latent backend bug they surfaced. **Independent, off `master`** (consolidates the former #721 + the source fix; #721 is closed in favour of this).

### Source fix — `faust/web/cache/backends/redis.py`

The import guard bound only `aredis` on failure:

```python
except ImportError:
    aredis = None        # <-- redis left unbound
```

but the backend guards on `if redis is None` (`on_start`, scheme/error setup). With redis genuinely uninstalled, `redis` stays *unbound* and the first `if redis is None` raises `NameError` at import instead of the intended `ImproperlyConfigured`. Fixed by binding **`redis = None`**, and dropped the **dead `import redis.asyncio as aredis`** alias (only ever assigned `None`, never referenced — its presence is what made the guard look correct).

### Tests — `tests/functional/web/test_cache.py`

- `Test_RedisScheme::test_single_client` / `test_cluster_client` — rewritten for redis-py 8.x: assert against the scheme→client map the backend actually builds (`_client_by_scheme`); single-node resolves to `redis.client.Redis` (built for real; connects lazily), cluster to `redis.RedisCluster` (mocked like the existing `mocked_redis` fixture, since it connects on construction). Scheme selection and `db`-stripping run for real.
- `test_redis__is_not_installed` (renamed from `…aredis_is_not_installed`) — patches the `redis` name the guard reads and asserts `ImproperlyConfigured` without opening a socket.

### Verification
`tests/functional/web/test_cache.py` → **32 passed**; the guard now raises `ImproperlyConfigured` (previously `NameError`), verified directly. flake8/black/isort clean.

### Not addressed (separate, larger concern)
The backend maps schemes to **sync** clients (`redis.StrictRedis`/`RedisCluster`) yet `await`s them in `_get`/`_set` — fine under the mocked tests, likely broken for real async use. Worth a dedicated look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)