### PR TITLE
ci: trigger on merge_group so a merge queue can be enabled

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,6 +5,10 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  # Run the checks on merge-queue candidates too, so a GitHub merge queue can
+  # be enabled on `master`: the queue tests each candidate as a `merge_group`
+  # event, and the required `check` job must run there or queued PRs stall.
+  merge_group:
   release:
     types: [created]
     branches: [master]


### PR DESCRIPTION
## Description

Makes `master` **merge-queue-ready**. A GitHub merge queue validates each candidate as a `merge_group` event, but the workflow only triggered on `push` / `pull_request` / `release` — so the required `check` job would never run for a queued PR and **the queue would stall indefinitely**. This adds the `merge_group` trigger:

```yaml
on:
  push:
    branches: [master]
  pull_request:
    branches: [master]
  merge_group:          # <-- added
  release:
    types: [created]
```

- No behaviour change for normal pushes/PRs.
- The `check` job (`needs: [lint, test-pytest]`, `alls-green`) is already the single aggregated required status a queue wants, and now runs on `merge_group` too.
- The advisory jobs (`test-integration`, `test-pypy`, `test-redis-integration`) stay `continue-on-error` / out of the `check` gate, so they won't block the queue.

### To actually turn the queue on (maintainer, repo settings — not doable from a PR)
Settings → **Rules / Rulesets** (or branch protection on `master`) → enable **"Require merge queue"** targeting `master`, with the required status check set to **✅ Ensure the required checks passing** (the `check` job). Pick merge method / max batch size as desired. This PR is the prerequisite; the toggle itself is admin-only.

_Top of the stacked chain (based on #725). YAML validated._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_