### PR TITLE
ci: trigger on merge_group (bootstrap the merge queue)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,6 +5,10 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  # Run the checks on merge-queue candidates too, so the merge queue enabled
+  # on `master` can validate each candidate as a `merge_group` event -- the
+  # required `check` job must run there or queued PRs stall.
+  merge_group:
   release:
     types: [created]
     branches: [master]


### PR DESCRIPTION
## Description

**Merge this first, directly onto `master`, to un-stall the merge queue.**

The merge queue is enabled on `master`, but `master`'s CI workflow only triggers on `push` / `pull_request` / `release` — **not `merge_group`**. A queue validates each candidate as a `merge_group` event, so the required `check` job never runs for queued PRs and merges stall. (The earlier trigger PR, #726, was based on the stacked chain and merged into that branch, not `master`, so `master` still lacks it.)

This is the same 4-line `on:` addition, but **based directly on `master`** so it can land without the whole chain:

```yaml
on:
  push: { branches: [master] }
  pull_request: { branches: [master] }
  merge_group:          # <-- added
  release: { types: [created] }
```

### How to land it (chicken-and-egg)
Because "require merge queue" is on, the normal Merge button will try to *queue* this PR too — which would stall for the same reason. Break the loop one of two ways:
- **Admin bypass:** merge this PR directly (repo admins can bypass the queue), **or**
- Temporarily turn **off** "Require merge queue", merge this PR, turn it back **on**.

Once this is on `master`, the queue is fully functional and everything else (including the stacked chain #716→#725) can go through it normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_