### PR TITLE
ci: build CPython 3.14 wheels (bump cibuildwheel to 4.x)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -203,7 +203,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        # cibuildwheel 2.21.3 predates CPython 3.14, so `build = "cp3*"`
+        # stopped at cp313 and no 3.14 wheels were published (issue #715).
+        # 4.x builds 3.14 by default and still supports cp310-cp313.
+        uses: pypa/cibuildwheel@v4.1.0
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,12 @@ testpaths = [
 build = "cp3*"
 
 archs = ["auto64"]
-skip = ["*musllinux*"]
+# Skip musllinux, and skip the free-threaded builds (cp313t/cp314t): as of
+# cibuildwheel 3.1 free-threading is no longer experimental for 3.14, so
+# `cp3*` would otherwise build free-threaded wheels for the Cython extension,
+# which has not been validated under a no-GIL interpreter.  Drop `cp31?t-*`
+# from this list once faust is verified free-threading-safe.
+skip = ["*musllinux*", "cp31?t-*"]
 
 before-build = "pip install Cython"
 


### PR DESCRIPTION
## Description

Fixes #715. Re-opens #718 **onto `master`** — #718 was merged into its stale stacked-parent branch (`claude/ci-confluent-driver-matrix`) instead of `master`, so its content never reached `master`. This branch is the same commit cherry-picked directly onto `master`, independent of any chain.

No CPython 3.14 wheels were published for 0.12.0/0.12.1, so installing on 3.14 forces a source build.

### Root cause

The release `build_wheels` job pinned `pypa/cibuildwheel@v2.21.3` (Oct 2024), which predates CPython 3.14. cibuildwheel only builds the interpreters its own release knows about, so `build = "cp3*"` expanded to at most `cp313` — no `cp314` wheels were produced.

### Fix

- Bump the action to **`pypa/cibuildwheel@v4.1.0`**, which builds CPython 3.14 by default and still supports cp310–cp313.
- Add `cp31?t-*` to `skip`, since 4.x would otherwise build free-threaded (`cp314t`) wheels and faust's Cython extension hasn't been validated under a no-GIL interpreter.

### Verification

`cibuildwheel --print-build-identifiers --platform linux` now lists cp310–cp314 manylinux, with `cp314t` and musllinux correctly excluded. Wheels are only produced on a `release: created` event, so this takes effect on the next tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_