### PR TITLE
test(assignor): fix flaky PyPy CI leg (disable Hypothesis deadline)

### DIFF
--- a/tests/meticulous/assignor/test_copartitioned_assignor.py
+++ b/tests/meticulous/assignor/test_copartitioned_assignor.py
@@ -8,7 +8,13 @@ from hypothesis.strategies import integers
 from faust.assignor.client_assignment import CopartitionedAssignment
 from faust.assignor.copartitioned_assignor import CopartitionedAssignor
 
-TEST_DEADLINE = 4000
+# These Hypothesis property tests assert assignment *correctness*, not
+# performance.  PyPy's JIT warmup makes a single example's timing vary by
+# well over a second, so a fixed deadline is tripped intermittently
+# (DeadlineExceeded -> FlakyFailure) even though the assignment is valid --
+# flaking the PyPy CI leg.  Disable the deadline; the job's own timeout still
+# guards against a real hang.
+TEST_DEADLINE = None
 
 
 _topics = {"foo", "bar", "baz"}


### PR DESCRIPTION
## Problem

Master CI intermittently goes red on the **`Python pypy3.11`** leg. The failure is:

```
hypothesis.errors.FlakyFailure: … produces unreliable results:
  Falsified on the first call but did not on a subsequent one
hypothesis.errors.DeadlineExceeded: Test took 5103.32ms, which exceeds the
  deadline of 4000.00ms …
```

in `tests/meticulous/assignor/test_copartitioned_assignor.py::test_remove_clients` (and its siblings).

## Root cause

Those copartitioned-assignor property tests now run on PyPy (the PyPy `skipif` guards were removed when full PyPy support landed). They carried a fixed **4000 ms** Hypothesis deadline. PyPy's JIT warmup makes a single example's timing vary by more than a second, so an example intermittently exceeds 4000 ms on its first run but not on retry — which Hypothesis reports as `DeadlineExceeded` → `FlakyFailure`. The assignment produced is perfectly valid; only the *timing* is nondeterministic. This flakes the (non-required) PyPy leg and turns the master run red.

## Fix

Set `TEST_DEADLINE = None`, disabling the Hypothesis deadline for these four property tests — exactly what the `DeadlineExceeded` message recommends. These tests assert assignment **correctness** (validity, stickiness, termination), not performance, so the deadline adds only flakiness. The property assertions are unchanged, and the CI job's own timeout still guards against a genuine hang.

## Verification

`pytest tests/meticulous/assignor/test_copartitioned_assignor.py` → **4 passed** (run takes ~5.7 s, confirming examples legitimately approach/exceed the old 4 s deadline). flake8/black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPL4VFWQRQPpjR1gXSKyL)_