### PR TITLE
Cap hypothesis work on PyPy so the PyPy CI leg stops timing out

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,29 @@ import pytest
 from _pytest.assertion.util import _compare_eq_dict, _compare_eq_set
 from aiohttp.client import ClientError, ClientSession
 from aiohttp.web import Response
+from hypothesis import HealthCheck, settings as hypothesis_settings
 from mode.utils.futures import all_tasks
 
 from tests.helpers import AsyncContextManagerMock, AsyncMock
+
+# Hypothesis runs its own machinery in pure Python, so PyPy generates and
+# shrinks examples far more slowly than CPython, and JIT warm-up makes
+# per-example deadlines meaningless -- a slow early example trips the
+# deadline and sends hypothesis into a long, silent shrinking search.  These
+# property tests used to be skipped on PyPy; #716 unskipped them, and at the
+# default budget they can now push the (advisory) PyPy CI leg past its
+# timeout.  Trade example count for wall-clock there only -- the CPython legs
+# keep running the full-size profile, so coverage of the properties is
+# unchanged where it is cheap to get.
+hypothesis_settings.register_profile(
+    "pypy",
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+
+if platform.python_implementation() == "PyPy":  # pragma: no cover
+    hypothesis_settings.load_profile("pypy")
 
 sentinel = object()
 

--- a/tests/meticulous/assignor/test_copartitioned_assignor.py
+++ b/tests/meticulous/assignor/test_copartitioned_assignor.py
@@ -1,4 +1,5 @@
 import copy
+import platform
 from collections import Counter
 from typing import MutableMapping
 
@@ -8,7 +9,11 @@ from hypothesis.strategies import integers
 from faust.assignor.client_assignment import CopartitionedAssignment
 from faust.assignor.copartitioned_assignor import CopartitionedAssignor
 
-TEST_DEADLINE = 4000
+# An explicit ``deadline=`` on @settings wins over the active hypothesis
+# profile, so the "pypy" profile registered in tests/conftest.py cannot clear
+# this on its own.  Drop the deadline on PyPy, where it measures JIT warm-up
+# rather than the assignor, and tripping it costs minutes of silent shrinking.
+TEST_DEADLINE = None if platform.python_implementation() == "PyPy" else 4000
 
 
 _topics = {"foo", "bar", "baz"}


### PR DESCRIPTION
The advisory PyPy leg has been running out of wall-clock.  On PR #699 it
stalled for 6m17s with no output after the last tests/integration/cli file
and was killed at the 15-minute job cap; the next file to run is
tests/meticulous/assignor/test_copartitioned_assignor.py, whose name never
reached the log, meaning its first test never reported.

That file is four hypothesis property tests at the default 100 examples
each.  All of them were skipped on PyPy until #716 removed the PyPy skips,
so PyPy started running them for the first time.  Hypothesis executes its
own generation and shrinking in pure Python, which PyPy runs slowly, and the
explicit deadline=4000 measures JIT warm-up rather than the assignor -- once
an example trips it, hypothesis drops into a silent shrinking search that
can burn minutes.  For scale, the whole of tests/meticulous is 5.8s on
CPython here, yet PyPy sat in it for over six minutes.

The leg has no headroom to absorb that: on the same base commit master takes
11m51s of the 15-minute budget, and raising the cap (already bumped 10 -> 15
by #716) only defers the problem, so cap the work instead.

Register a "pypy" hypothesis profile in tests/conftest.py -- 20 examples, no
deadline, too_slow health check suppressed -- and load it only when running
on PyPy.  CPython legs keep the full-size profile, so property coverage is
unchanged where it is cheap to get.

An explicit deadline= on @settings overrides the active profile (verified),
so the profile alone cannot clear the assignor deadline; TEST_DEADLINE is
made None on PyPy for that reason.

Verified: under a simulated PyPy interpreter the tests resolve to
deadline=None and max_examples=20; tests/meticulous drops from 4.95s to
1.40s under the profile on CPython while the default run is unchanged; full
suite 2217 passed; isort/black/flake8 clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017K8xAH8Z3xWKHhNRCG2mg1