### PR TITLE
Cache and de-duplicate the CI work that is repeated every run

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,12 @@ on:
     branches: [master]
   schedule:
     - cron: 19 10 * * 6
+# Supersede a pull request's analysis when it gets a new push; scheduled and
+# master runs (which populate the caches and the security dashboard) always run
+# to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   analyze:
     name: Analyze
@@ -43,6 +49,9 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
+          # Cache the dependencies the Python extractor installs to resolve
+          # imports, instead of leaving it to a server-side feature flag.
+          dependency-caching: true
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,21 +8,99 @@ on:
   release:
     types: [created]
     branches: [master]
+env:
+  FORCE_COLOR: '1'  # Make tools pretty.
+  PIP_DISABLE_PIP_VERSION_CHECK: '1'
+  PIP_NO_PYTHON_VERSION_WARNING: '1'
+  PYTHON_LATEST: '3.12'
+# Same policy as the CI/CD workflow: a new push to a pull request supersedes
+# the docs build of the commit it replaces, while `push` and `release` runs --
+# the ones that seed the cache and publish the site -- always run to
+# completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   build:
     name: Build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
+      # Checkout first: the pip cache key below hashes the requirements files,
+      # which have to be on disk before `setup-python` runs.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
+      - uses: actions/setup-python@v5
+        with:
+          # Pin the interpreter -- the step used to take whatever the runner
+          # image shipped -- and cache the wheels.  Sphinx and its extensions
+          # were previously downloaded from PyPI on every single run.
+          python-version: ${{ env.PYTHON_LATEST }}
+          cache: pip
+          cache-dependency-path: |
+            requirements/*.txt
+            requirements/extras/*.txt
+      # Sphinx builds incrementally: given its doctree cache and the HTML tree
+      # it wrote last time, it only re-reads and re-writes the documents whose
+      # sources changed -- including the `faust` modules autodoc imports, which
+      # it records as dependencies.  Restoring both turns the ~2 minute
+      # from-scratch build into the delta for this branch.  A Sphinx upgrade or
+      # a conf.py change invalidates the environment on its own, so a full
+      # rebuild still happens whenever the build itself changes.
+      #
+      # Saving is restricted to master pushes on purpose.  The primary key
+      # covers the package sources, so nearly every pull request misses it and
+      # would write a fresh multi-megabyte entry; against the repository-wide
+      # 10 GB cache budget that churn would evict the pip caches every few
+      # days.  Pull requests read the newest master entry instead -- usually
+      # only a commit or two behind -- and write nothing.
+      - name: Restore the Sphinx build cache
+        id: sphinx-cache
+        # Releases are what gets published: build those from scratch rather
+        # than on top of a doctree cache.
+        if: github.event_name != 'release'
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            docs/_build/doctrees
+            Documentation
+          key: >-
+            sphinx-${{ runner.os }}-py${{ env.PYTHON_LATEST }}-${{ hashFiles(
+            'docs/**', 'faust/**/*.py', 'requirements/docs.txt',
+            'requirements/requirements.txt', 'README.md', 'CHANGELOG.md') }}
+          restore-keys: |
+            sphinx-${{ runner.os }}-py${{ env.PYTHON_LATEST }}-
+      # `make docs` builds into docs/_build/html and then moves the result to
+      # Documentation/ (which is what the cache holds), so put the previous
+      # output back where Sphinx expects to find it before building.
+      - name: Seed the Sphinx output directory from the cache
+        run: |
+          if [ -d Documentation ]; then
+            mkdir -p docs/_build
+            rm -rf docs/_build/html
+            mv Documentation docs/_build/html
+          fi
       - name: Install runtime dependencies
+        # The docs import faust for autodoc but never touch the compiled
+        # accelerators, so skip building the C extensions here.
+        env:
+          NO_CYTHON: '1'
         run: |
           pip install .
           pip install -r requirements/docs.txt
       - name: Install doc build deps and build with Sphinx
         run: make docs
+      - name: Save the Sphinx build cache
+        if: >-
+          github.event_name == 'push'
+          && github.ref == 'refs/heads/master'
+          && steps.sphinx-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            docs/_build/doctrees
+            Documentation
+          key: ${{ steps.sphinx-cache.outputs.cache-primary-key }}
       - name: Upload artifacts
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,6 +17,18 @@ env:
   PIP_DISABLE_PIP_VERSION_CHECK: '1'
   PIP_NO_PYTHON_VERSION_WARNING: '1'
   PYTHON_LATEST: '3.12'
+# One run per pull request at a time: a new push supersedes the run of the
+# commit it replaces, so the ~45 job-minutes of a full matrix are not spent
+# validating a commit nobody will ever merge.
+#
+# Cancellation is deliberately limited to `pull_request`.  Every other event
+# gets its own group and always runs to completion: a cancelled `merge_group`
+# candidate would stall the merge queue, a cancelled `release` would skip
+# publishing, and `push` runs on master are what seed the caches everything
+# else restores from.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   lint:
     name: Check linting
@@ -31,6 +43,17 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_LATEST }}
           cache: pip
+          # Hash every requirements file the workflow installs from, not just
+          # the default `**/requirements.txt`.  The pins this job actually
+          # installs live in test.txt, which pulls requirements.txt and several
+          # extras/ files in via `-r`; with the default pattern the key never
+          # moved when those changed, so the entry could neither be refreshed
+          # (a hit never re-saves) nor serve the packages that were added.
+          # Every job here uses the same list so they all share one entry per
+          # interpreter instead of each warming a partial one.
+          cache-dependency-path: |
+            requirements/*.txt
+            requirements/extras/*.txt
       - run: |
           python -m pip install build
           python -m pip install -r requirements/test.txt
@@ -89,7 +112,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: requirements/test.txt
+          # See the lint job: test.txt alone leaves the key unchanged when the
+          # transitively-included pins move, and the confluent legs below
+          # install extras/ckafka.txt on top of it.
+          cache-dependency-path: |
+            requirements/*.txt
+            requirements/extras/*.txt
       - name: Install dependencies
         run: |
           pip install -r requirements/test.txt
@@ -128,7 +156,9 @@ jobs:
         with:
           python-version: pypy3.11
           cache: pip
-          cache-dependency-path: requirements/test.txt
+          cache-dependency-path: |
+            requirements/*.txt
+            requirements/extras/*.txt
       - name: Install dependencies
         id: install
         continue-on-error: true
@@ -166,7 +196,11 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-          cache-dependency-path: requirements/test.txt
+          # This job also installs extras/ckafka.txt, which the old
+          # test.txt-only key did not cover.
+          cache-dependency-path: |
+            requirements/*.txt
+            requirements/extras/*.txt
       # Run Kafka as a plain container (not a GH `services:` container) so its
       # very chatty broker log stays inside the container -- retrievable on
       # demand via `docker logs` -- and the job log shows the pytest output.
@@ -240,7 +274,9 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-          cache-dependency-path: requirements/test.txt
+          cache-dependency-path: |
+            requirements/*.txt
+            requirements/extras/*.txt
       - name: Install dependencies
         run: |
           pip install -r requirements/test.txt
@@ -298,6 +334,14 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5
+        with:
+          # Pin the interpreter (the step previously took whatever the runner
+          # image shipped) so the pip cache below has a stable key.
+          python-version: ${{ env.PYTHON_LATEST }}
+          cache: pip
+          cache-dependency-path: |
+            requirements/*.txt
+            requirements/extras/*.txt
       - name: Build sdist
         # Use `python -m build`, not the deprecated `setup.py sdist`, so the
         # sdist is named with the normalized project name


### PR DESCRIPTION
Measured against a recent pull request run (~46 job-minutes, ~13 minutes
wall clock), three kinds of work were being redone from scratch on every
push.

Cancel superseded pull request runs.  None of the three workflows had a
`concurrency` group, so pushing twice to a branch left the first run's
full matrix -- 24 jobs -- grinding away on a commit that will never be
merged.  Cancellation is scoped to `pull_request` only: `merge_group`,
`push` and `release` runs keep their own groups and always finish, so a
merge-queue candidate cannot stall and a release cannot skip publishing.

Fix the pip cache keys.  The test jobs keyed their cache on
`requirements/test.txt` alone and the lint job on the default
`**/requirements.txt`, but test.txt pulls in requirements.txt and six
extras/ files via `-r`, and the confluent and Kafka legs install
extras/ckafka.txt on top.  A key that does not move when those pins move
can never be refreshed -- a cache hit never re-saves -- so newly added
or bumped packages were re-downloaded on every run forever.  All jobs now
hash the same file set, which also lets them share one entry per
interpreter instead of each warming a partial one.

Make the docs build incremental.  The Pages workflow had no pip cache at
all (Sphinx and its extensions came off PyPI every run, ~23s) and rebuilt
all of the documentation from scratch (~133s of a 166s job).  It now
caches the doctree environment plus the previous HTML tree, which is
exactly what Sphinx needs to rebuild only the documents whose sources
changed.  Writing that cache is restricted to master pushes: the key
covers the package sources, so nearly every pull request would miss it
and write a fresh multi-megabyte entry, and that churn would evict the
pip caches from the repository's 10 GB budget.  Pull requests read the
newest master entry and write nothing.  Release runs skip the cache
entirely and build clean, since a release is what gets published.

Also enable CodeQL's dependency caching, pin the two interpreters that
were previously whatever the runner image happened to ship (the docs and
sdist jobs, which a cache key needs to be stable), and skip building the
C accelerators in the docs job, which imports faust for autodoc but never
calls into them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMogYcWDypGis1q4bMzB1N