### PR TITLE
Align confluent driver type annotations with the aiokafka driver

### DIFF
--- a/faust/transport/drivers/confluent.py
+++ b/faust/transport/drivers/confluent.py
@@ -3,6 +3,7 @@
 import asyncio
 import typing
 from collections import defaultdict
+from logging import Logger
 from time import monotonic
 from typing import (
     Any,
@@ -26,6 +27,7 @@ from mode import Service, get_logger
 from mode.threads import QueueServiceThread
 from mode.utils.futures import notify
 from mode.utils.times import Seconds, want_seconds
+from mode.utils.types.trees import NodeT
 from yarl import URL
 
 from faust.exceptions import ConsumerNotStarted, ProducerSendError
@@ -38,7 +40,12 @@ from faust.transport.consumer import (
     ensure_TPset,
 )
 from faust.types import TP, AppT, ConsumerMessage, HeadersArg, RecordMetadata
-from faust.types.transports import ConsumerT, ProducerT
+from faust.types.transports import (
+    ConsumerT,
+    PartitionsAssignedCallback,
+    PartitionsRevokedCallback,
+    ProducerT,
+)
 
 if typing.TYPE_CHECKING:
     from confluent_kafka import (
@@ -82,11 +89,11 @@ class Consumer(ThreadDelegateConsumer):
         partitions: int,
         replication: int,
         *,
-        config: Mapping[str, Any] = None,
+        config: Optional[Mapping[str, Any]] = None,
         timeout: Seconds = 30.0,
-        retention: Seconds = None,
-        compacting: bool = None,
-        deleting: bool = None,
+        retention: Optional[Seconds] = None,
+        compacting: Optional[bool] = None,
+        deleting: Optional[bool] = None,
         ensure_created: bool = False,
     ) -> None:
         """Create topic on broker."""
@@ -150,14 +157,14 @@ class Consumer(ThreadDelegateConsumer):
 class AsyncConsumer:
     def __init__(
         self,
-        config,
-        logger=None,
-        callback=None,
-        loop=None,
-        on_partitions_revoked=None,
-        on_partitions_assigned=None,
-        beacon=None,
-    ):
+        config: Mapping[str, Any],
+        logger: Optional[Logger] = None,
+        callback: Optional[Callable[[_Message], Awaitable[None]]] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        on_partitions_revoked: Optional[PartitionsRevokedCallback] = None,
+        on_partitions_assigned: Optional[PartitionsAssignedCallback] = None,
+        beacon: Optional[NodeT] = None,
+    ) -> None:
         """Construct a Consumer usable within asyncio.
 
         :param config: A configuration dict for this Consumer
@@ -170,16 +177,16 @@ class AsyncConsumer:
         self.beacon = beacon
         self.loop = loop
 
-    def close(self):
+    def close(self) -> None:
         self.consumer.close()
 
-    def subscribe(self, *args, **kwargs):
+    def subscribe(self, *args: Any, **kwargs: Any) -> None:
         self.consumer.subscribe(*args, **kwargs)
 
-    def assign(self, *args, **kwargs):
+    def assign(self, *args: Any, **kwargs: Any) -> None:
         self.consumer.assign(*args, **kwargs)
 
-    async def poll(self, timeout=1.0):
+    async def poll(self, timeout: float = 1.0) -> Optional[_Message]:
         """Consume a single message and call the registered callback.
 
         Delegates to the blocking :meth:`confluent_kafka.Consumer.poll`.
@@ -198,7 +205,7 @@ class AsyncConsumer:
             await self.callback(msg)
         return msg
 
-    def assignment(self) -> Set[TP]:
+    def assignment(self) -> List[_TopicPartition]:
         return self.consumer.assignment()
 
 
@@ -305,7 +312,7 @@ class ConfluentConsumerThread(ConsumerThread):
             await consumer.consumer.seek(tp)
         return {ensure_TP(tp): tp.offset for tp in committed}
 
-    async def _committed_offsets(self, partitions: List[TP]) -> MutableMapping[TP, int]:
+    async def _committed_offsets(self, partitions: List[TP]) -> Mapping[TP, int]:
         consumer = self._ensure_consumer()
         committed = consumer.consumer.committed(
             [_TopicPartition(tp[0], tp[1]) for tp in partitions]
@@ -359,12 +366,12 @@ class ConfluentConsumerThread(ConsumerThread):
         # XXX NotImplemented
         return None
 
-    async def earliest_offsets(self, *partitions: TP) -> MutableMapping[TP, int]:
+    async def earliest_offsets(self, *partitions: TP) -> Mapping[TP, int]:
         if not partitions:
             return {}
         return await self.call_thread(self._earliest_offsets, partitions)
 
-    async def _earliest_offsets(self, partitions: List[TP]) -> MutableMapping[TP, int]:
+    async def _earliest_offsets(self, partitions: List[TP]) -> Mapping[TP, int]:
         consumer = self._ensure_consumer()
         return {
             tp: consumer.consumer.get_watermark_offsets(_TopicPartition(tp[0], tp[1]))[
@@ -373,12 +380,12 @@ class ConfluentConsumerThread(ConsumerThread):
             for tp in partitions
         }
 
-    async def highwaters(self, *partitions: TP) -> MutableMapping[TP, int]:
+    async def highwaters(self, *partitions: TP) -> Mapping[TP, int]:
         if not partitions:
             return {}
         return await self.call_thread(self._highwaters, partitions)
 
-    async def _highwaters(self, partitions: List[TP]) -> MutableMapping[TP, int]:
+    async def _highwaters(self, partitions: List[TP]) -> Mapping[TP, int]:
         consumer = self._ensure_consumer()
         return {
             tp: consumer.consumer.get_watermark_offsets(_TopicPartition(tp[0], tp[1]))[
@@ -414,19 +421,19 @@ class ConfluentConsumerThread(ConsumerThread):
         partitions: int,
         replication: int,
         *,
-        config: Mapping[str, Any] = None,
+        config: Optional[Mapping[str, Any]] = None,
         timeout: Seconds = 30.0,
-        retention: Seconds = None,
-        compacting: bool = None,
-        deleting: bool = None,
+        retention: Optional[Seconds] = None,
+        compacting: Optional[bool] = None,
+        deleting: Optional[bool] = None,
         ensure_created: bool = False,
     ) -> None:
         return  # XXX
 
     def key_partition(
-        self, topic: str, key: Optional[bytes], partition: int = None
+        self, topic: str, key: Optional[bytes], partition: Optional[int] = None
     ) -> Optional[int]:
-        metadata = self._consumer.consumer.list_topics(topic)
+        metadata = self._ensure_consumer().consumer.list_topics(topic)
         partition_count = len(metadata.topics[topic]["partitions"])
 
         # Calculate the partition number based on the key hash
@@ -486,10 +493,10 @@ class ProducerThread(QueueServiceThread):
     def produce(
         self,
         topic: str,
-        key: bytes,
-        value: bytes,
-        partition: int,
-        on_delivery: Callable,
+        key: Optional[bytes],
+        value: Optional[bytes],
+        partition: Optional[int],
+        on_delivery: Callable[[Optional[BaseException], _Message], None],
     ) -> None:
         if self._producer is None:
             raise RuntimeError("Producer not started")
@@ -563,11 +570,11 @@ class Producer(base.Producer):
         partitions: int,
         replication: int,
         *,
-        config: Mapping[str, Any] = None,
+        config: Optional[Mapping[str, Any]] = None,
         timeout: Seconds = 20.0,
-        retention: Seconds = None,
-        compacting: bool = None,
-        deleting: bool = None,
+        retention: Optional[Seconds] = None,
+        compacting: Optional[bool] = None,
+        deleting: Optional[bool] = None,
         ensure_created: bool = False,
     ) -> None:
         """Create topic on broker."""
@@ -605,7 +612,7 @@ class Producer(base.Producer):
         timestamp: Optional[float],
         headers: Optional[HeadersArg],
         *,
-        transactional_id: str = None,
+        transactional_id: Optional[str] = None,
     ) -> Awaitable[RecordMetadata]:
         """Send message for future delivery."""
         fut = ProducerProduceFuture(loop=self.loop)
@@ -634,7 +641,7 @@ class Producer(base.Producer):
         timestamp: Optional[float],
         headers: Optional[HeadersArg],
         *,
-        transactional_id: str = None,
+        transactional_id: Optional[str] = None,
     ) -> RecordMetadata:
         """Send message and wait for it to be delivered to broker(s)."""
         fut = await self.send(
@@ -678,7 +685,10 @@ class Transport(base.Transport):
     driver_version = f"confluent_kafka={confluent_kafka.__version__}"
 
     def _topic_config(
-        self, retention: int = None, compacting: bool = None, deleting: bool = None
+        self,
+        retention: Optional[int] = None,
+        compacting: Optional[bool] = None,
+        deleting: Optional[bool] = None,
     ) -> MutableMapping[str, Any]:
         config: MutableMapping[str, Any] = {}
         cleanup_flags: Set[str] = set()

--- a/faust/transport/drivers/confluent.py
+++ b/faust/transport/drivers/confluent.py
@@ -496,7 +496,11 @@ class ProducerThread(QueueServiceThread):
         key: Optional[bytes],
         value: Optional[bytes],
         partition: Optional[int],
-        on_delivery: Callable[[Optional[BaseException], _Message], None],
+        # Deliberately unparameterised: confluent hands the callback a
+        # KafkaError, which is not a BaseException, and set_from_on_delivery
+        # passes it straight to Future.set_exception.  A precise signature
+        # here would paper over that bug rather than fix it.
+        on_delivery: Callable,
     ) -> None:
         if self._producer is None:
             raise RuntimeError("Producer not started")


### PR DESCRIPTION
## Description

`faust/transport/drivers/confluent.py` was the only transport driver still carrying implicit-`Optional` parameter defaults and fully unannotated functions — patterns absent from `faust/transport/drivers/aiokafka.py` sitting next to it. This PR brings the confluent driver's annotations up to the same standard, without reworking its logic.

### What changed

- **Explicit `Optional[...]` for every `None` default** — `config`, `retention`, `compacting`, `deleting`, `transactional_id`, `partition`. PEP 484 prohibits implicit `Optional`, so these were also Liskov violations against the `ConsumerT` / `ProducerT` / `ConsumerThread` supertypes, which already declare the widened types. Affects `Consumer.create_topic`, `ConfluentConsumerThread.create_topic`, `ConfluentConsumerThread.key_partition`, `Producer.create_topic`, `Producer.send`, `Producer.send_and_wait`, and `Transport._topic_config`.
- **`AsyncConsumer` is now annotated** — `__init__` plus `close` / `subscribe` / `assign` / `poll`, reusing the `PartitionsRevokedCallback` and `PartitionsAssignedCallback` aliases faust already defines in `faust.types.transports`.
- **`AsyncConsumer.assignment()` returns `List[TopicPartition]`**, which is what `confluent_kafka.Consumer.assignment()` actually returns, rather than `Set[TP]`. `ConfluentConsumerThread.assignment()` already funnels the result through `ensure_TPset()`.
- **`earliest_offsets` / `highwaters` (and their helpers) return `Mapping[TP, int]`**, matching both the `ConsumerThread` base class and the aiokafka driver, instead of needlessly narrowing to `MutableMapping`.
- **`ProducerThread.produce`** takes optional key/value/partition — which is what the `if partition is not None` branch in its own body already assumes. `on_delivery` is deliberately left as a bare `Callable`; see below.
- **`ConfluentConsumerThread.key_partition` reaches the consumer via `_ensure_consumer()`**, like every other method in the class, so an unstarted thread raises `ConsumerNotStarted` rather than an `AttributeError` on `None`. This is the only behaviour change in the PR, and it mirrors `AIOKafkaConsumerThread.key_partition`.

### Effect on mypy

Numbers depend on the mypy version, because 2.x reads inline types from `py.typed` packages (including `confluent_kafka`) that 1.x ignored. Both directions are an improvement:

| | confluent.py | whole package |
|---|---|---|
| mypy 2.3.0 (current release) | 53 → **17** | 692 → **656** |
| mypy 1.19.1 | 38 → **0** | 552 → **514** |

A file-by-file diff of the full error list confirms **no other module changes** in either case.

The 17 remaining under 2.3.0 are all pre-existing defects, and several become visible only *because* of this PR: annotating `AsyncConsumer.__init__` lets mypy resolve `self.consumer` to the real `confluent_kafka.Consumer` instead of `Any`, so call sites that were previously unchecked now get checked. What it surfaces is genuine — `AsyncConsumer` defines neither `seek` nor `seek_to_beginning`, yet `_seek_wait` and `seek_to_beginning` call both; and several sync callables are handed to `call_thread`, which expects awaitables.

### On `on_delivery`

An earlier revision of this branch annotated it `Callable[[Optional[BaseException], _Message], None]`, reasoning from `ProducerProduceFuture.set_from_on_delivery`'s own signature. That is wrong: confluent's stubs declare `Callable[[Optional[KafkaError], Message], None]`, and `KafkaError` does **not** derive from `BaseException` — `KafkaException` is the exception type, `KafkaError` is a plain status object. So `set_from_on_delivery`'s `self.set_exception(err)` is handed a non-exception and raises `TypeError` instead of failing the future with the delivery error. The `# XXX Not sure what err is here` comment above it turns out to have been well founded. Fixing that is a behaviour change and belongs in its own patch, so the parameter is left as a bare `Callable` with a comment recording why.

### Other latent bugs found, not fixed here

- `Producer.send` calls `ProducerThread.produce(topic, value, key, partition)` against a `(topic, key, value, partition)` signature — key and value are swapped.
- `Producer.key_partition` calls `self._producer_thread.producer.list_topics(...)`, but `ProducerThread.producer` is the faust `Producer`, which has no such method.

### Verification

- `pytest tests/unit/transport/drivers/test_confluent.py` — 57 passed (the same suite the dedicated confluent CI leg runs).
- `isort --check`, `black --check`, and `flake8` clean on the changed file.

No issue to link; this is a type-annotation cleanup. Follow-up #757 wires mypy into CI behind a ratchet so this class of regression is caught automatically.