### PR TITLE
Enforce mypy in CI behind a ratchet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,109 @@ combine_as_imports = true
 [tool.mypy]
 ignore_missing_imports = true
 disallow_untyped_defs = true
+# Pinned so the result does not depend on which interpreter runs mypy.  Without
+# it mypy targets the running version, and typeshed differs enough between them
+# that a contributor on 3.10 and the lint job on PYTHON_LATEST would disagree
+# about whether the tree is clean.  Tracks the lint job's interpreter; raising
+# it can surface new errors, so bump it deliberately.
+python_version = "3.12"
+
+# Type-checking ratchet.
+#
+# `scripts/check` runs `mypy -p faust`, so it has to exit zero.  The package is
+# not clean yet, so the modules that still have errors are silenced here.
+# Everything NOT listed is checked -- today that is 86 of faust's 164 modules,
+# plus every module added from here on.
+#
+# This list may only shrink.  Do not add a module to it to turn a red build
+# green; fix the annotations instead.  When you clean one up, delete its line
+# in the same pull request so it cannot regress.  To see what is outstanding,
+# comment this section out and run `mypy -p faust`.
+#
+# Regenerating it requires the pinned mypy from requirements/typecheck.txt; a
+# different version reports a different set.
+[[tool.mypy.overrides]]
+module = [
+  "faust",
+  "faust.agents.agent",
+  "faust.app._attached",
+  "faust.app.base",
+  "faust.app.router",
+  "faust.assignor.client_assignment",
+  "faust.assignor.partition_assignor",
+  "faust.auth",
+  "faust.channels",
+  "faust.cli.base",
+  "faust.cli.worker",
+  "faust.contrib.sentry",
+  "faust.events",
+  "faust.livecheck.app",
+  "faust.livecheck.case",
+  "faust.livecheck.signals",
+  "faust.models.base",
+  "faust.models.fields",
+  "faust.models.record",
+  "faust.models.typing",
+  "faust.sensors.base",
+  "faust.sensors.datadog",
+  "faust.sensors.distributed_tracing",
+  "faust.sensors.monitor",
+  "faust.sensors.prometheus",
+  "faust.sensors.statsd",
+  "faust.serializers.codecs",
+  "faust.serializers.schemas",
+  "faust.stores.aerospike",
+  "faust.stores.base",
+  "faust.stores.rocksdb",
+  "faust.streams",
+  "faust.tables.base",
+  "faust.tables.globaltable",
+  "faust.tables.manager",
+  "faust.tables.objects",
+  "faust.tables.recovery",
+  "faust.tables.sets",
+  "faust.tables.table",
+  "faust.topics",
+  "faust.transport.conductor",
+  "faust.transport.consumer",
+  "faust.transport.drivers.aiokafka",
+  "faust.transport.drivers.confluent",
+  "faust.transport.producer",
+  "faust.transport.utils",
+  "faust.types.agents",
+  "faust.types.app",
+  "faust.types.auth",
+  "faust.types.channels",
+  "faust.types.codecs",
+  "faust.types.models",
+  "faust.types.sensors",
+  "faust.types.serializers",
+  "faust.types.settings.params",
+  "faust.types.settings.settings",
+  "faust.types.stores",
+  "faust.types.streams",
+  "faust.types.tables",
+  "faust.types.topics",
+  "faust.types.transports",
+  "faust.types.tuples",
+  "faust.types.web",
+  "faust.utils._opentracing",
+  "faust.utils.agent_stopper",
+  "faust.utils.codegen",
+  "faust.utils.cron",
+  "faust.utils.terminal.tables",
+  "faust.utils.tracing",
+  "faust.utils.venusian",
+  "faust.web.base",
+  "faust.web.blueprints",
+  "faust.web.cache.backends.redis",
+  "faust.web.cache.cache",
+  "faust.web.drivers.aiohttp",
+  "faust.web.views",
+  "faust.windows",
+  "faust.worker",
+]
+ignore_errors = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -27,6 +27,9 @@ twine
 wheel
 intervaltree
 -r requirements.txt
+# mypy, pinned for the same reason as the formatters above: `scripts/check`
+# type-checks the faust package, so the lint job needs it installed.
+-r typecheck.txt
 -r extras/datadog.txt
 -r extras/opentracing.txt
 -r extras/redis.txt

--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -1,1 +1,5 @@
-mypy>=0.750
+# Pinned for the same reason as the formatters in test.txt: a new mypy release
+# adds checks, which would turn an otherwise-unchanged tree red.  Bump it
+# deliberately, together with whatever ratchet-list changes the new version
+# demands (see [[tool.mypy.overrides]] in pyproject.toml).
+mypy==2.3.0

--- a/scripts/check
+++ b/scripts/check
@@ -11,4 +11,6 @@ set -x
 ${PREFIX}isort --check --diff --project=faust $SOURCE_FILES
 ${PREFIX}black --check --diff $SOURCE_FILES
 ${PREFIX}flake8 $SOURCE_FILES
-# ${PREFIX}mypy $SOURCE_FILES
+# Checks the faust package only, and only the modules that are already clean:
+# see the ratchet list under [[tool.mypy.overrides]] in pyproject.toml.
+${PREFIX}mypy -p faust


### PR DESCRIPTION
## Description

Follow-up to #756, which slipped through because **nothing in CI type-checks.**

- The lint job runs `scripts/check` and nothing else, and the mypy line in that script has been commented out since the file was added in `df20a17` — it never ran.
- `tox -e typecheck` and `make typecheck` do invoke `mypy -p faust`, but no workflow invokes tox or make, so they only fire if a contributor runs them by hand.
- `[tool.mypy]` in `pyproject.toml` has been configured the whole time with nothing reading it in anger.
- flake8 cannot cover for it: pycodestyle and pyflakes do no type inference, so implicit-`Optional` defaults and missing annotations are invisible to the checks that do run.

`mypy -p faust` reports 692 errors across 78 modules, so it can't simply be switched on. This adds a ratchet instead.

### How it works

`[[tool.mypy.overrides]]` with `ignore_errors = true` silences exactly the 78 modules that still have errors. **The other 86 are enforced** — as is every module added to the package from here on, since anything not on the list is checked by default. The list is documented to only ever shrink: cleaning up a module means deleting its line in the same PR, so it can't regress.

Using mypy's own per-module config rather than a shell allowlist or grep-filtered output means `mypy -p faust` just exits zero, and `tox -e typecheck` / `make typecheck` become useful again for free.

### Two things had to be pinned first

Without these the check is red on one machine and green on another:

- **`python_version` was unset**, so mypy targeted whichever interpreter ran it. Pinned to `3.12`, the lint job's interpreter. Typeshed differs enough between versions to change the verdict — `faust/app/_attached.py` is clean targeting 3.10 but reports `asyncio.wait` receiving a bare `Awaitable` from 3.11 on, which is a real hazard given the CI matrix runs through 3.14.
- **`mypy>=0.750` floats to whatever is newest**, and the enforced set moves with it. 1.19.1 and 2.3.0 disagree about 6 modules, largely because 2.x reads inline types from `py.typed` packages that 1.x ignored. Pinned to `2.3.0` for the same reason `test.txt` already pins the formatters, and `typecheck.txt` is now pulled into `test.txt` so the lint job installs it.

### Verification

Against merged `master` (`aeec5f3`):

- `scripts/check` exits `0` **with** confluent-kafka installed and **without** it — the lint job doesn't install that extra, and the silenced set is identical either way, so the check can't pass locally and fail in CI over an optional dependency.
- The list is exact: 78 listed, 78 dirty, no module dirty-but-unlisted (which would fail CI) and none listed-but-already-clean (which would be dead weight).
- Appending an unannotated `def _ratchet_probe(x): return x` to `faust/utils/urls.py` (an enforced module) fails the check with `error: Function is missing a type annotation`, exit `1`. Reverted after testing.
- No source files are touched by this PR — only `pyproject.toml`, `scripts/check`, and two requirements files.

### Note on scope

`faust/transport/drivers/confluent.py` is on the silenced list despite #756. Under the pinned mypy that PR takes it from 53 errors to 17, not to zero: annotating `AsyncConsumer.__init__` lets mypy resolve `self.consumer` to the real `confluent_kafka.Consumer` instead of `Any`, which surfaces pre-existing bugs (`AsyncConsumer` has no `seek` or `seek_to_beginning`; sync callables passed to `call_thread`, which wants awaitables). Those are real defects worth their own PR, and removing that line from the ratchet list is the natural way to close it out.