### PR TITLE
Build through setuptools rather than the distutils shim

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,25 @@
 import os
 import re
 import sys
-from distutils.command.build_ext import build_ext
-from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
 
 from setuptools import Extension, find_packages, setup
+
+# setuptools, not distutils: distutils was removed from the standard library
+# in Python 3.12 (PEP 632), and `import distutils` only keeps working because
+# setuptools injects a replacement early via its `_distutils_hack`.  That is a
+# compatibility shim, not an API to build on -- and it is not always in place,
+# so on an interpreter without setuptools importable this failed with a bare
+# `ModuleNotFoundError: No module named 'distutils'` before reaching the line
+# above that actually needs setuptools.
+#
+# These are the public equivalents; `setuptools.errors` has exposed them since
+# setuptools 59, well below the >=69 floor in pyproject.toml.
+from setuptools.command.build_ext import build_ext
+from setuptools.errors import (
+    CCompilerError,
+    ExecError,
+    PlatformError,
+)
 
 try:
     from Cython.Build import cythonize
@@ -106,7 +121,7 @@ class ve_build_ext(build_ext):
     def run(self):
         try:
             build_ext.run(self)
-        except (DistutilsPlatformError, FileNotFoundError):
+        except (PlatformError, FileNotFoundError):
             raise BuildFailed()
 
     def build_extension(self, ext):
@@ -114,8 +129,8 @@ class ve_build_ext(build_ext):
             build_ext.build_extension(self, ext)
         except (
             CCompilerError,
-            DistutilsExecError,
-            DistutilsPlatformError,
+            ExecError,
+            PlatformError,
             ValueError,
         ):
             raise BuildFailed()


### PR DESCRIPTION
## Description

`setup.py` imported `build_ext` and the compiler exceptions from `distutils`. That module was **removed from the standard library in Python 3.12** (PEP 632); `import distutils` only keeps working because setuptools injects a replacement early via its `_distutils_hack`.

Relying on that shim is fragile in two ways. It is a compatibility layer setuptools maintains for legacy code rather than an API to build on, and it is not always in place — when setuptools is not importable the build failed with a message naming a module nobody asked for:

```
# before
ModuleNotFoundError: No module named 'distutils'

# after, same environment
ModuleNotFoundError: No module named 'setuptools'
```

`setuptools.command.build_ext` and `setuptools.errors` are the public equivalents. `setuptools.errors` has exposed `CCompilerError`, `ExecError` and `PlatformError` since setuptools 59 — well below the `>=69` floor already in `pyproject.toml`'s `build-system.requires`.

### Verification

The graceful-degradation path is what these exceptions are *for*, so it was checked rather than assumed. Building a wheel with a deliberately broken compiler (`CC=/nonexistent-compiler`):

```
Cannot compile C accelerated modules, using pure python
extensions in wheel: 0
```

A normal build produces 3 extensions on CPython 3.12, 3.13 and free-threaded 3.14 alike. Full suite: 2207 passed. `flake8` / `black` / `isort` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8qT5E3rnSXvw7ibNLXrVr)_