### PR TITLE
Install the build toolchain, so a direct setup.py invocation works

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,0 +1,35 @@
+# The build toolchain, installable into the ambient interpreter.
+#
+# `pip install .` does not need this file: PEP 517 build isolation reads
+# `[build-system].requires` from pyproject.toml and provisions those packages
+# into a throwaway environment that is discarded once the wheel is built.
+# Nothing they contain is left behind on the interpreter that ran pip.
+#
+# Anything that drives the build *directly* does need it -- notably
+# `python setup.py build_ext --inplace`, which is how the compiled extensions
+# end up next to the .pyx files in the source tree (the only place an
+# `import faust` from the repository root will find them; a build into
+# site-packages is never imported by the test suite).
+#
+# Two failure modes make this worth pinning down rather than leaving to
+# whatever the interpreter happens to ship:
+#
+# * setuptools is no longer bundled.  Since Python 3.12 removed distutils
+#   (PEP 632), `ensurepip` stopped seeding setuptools into new environments,
+#   so a bare 3.12+ interpreter -- including the ones `actions/setup-python`
+#   provides -- has none.  `setup.py` then dies at its first import with
+#   `ModuleNotFoundError: No module named 'setuptools'`.
+#
+# * A missing Cython fails *silently*.  setup.py falls back to compiling
+#   pre-generated .c files, which this repository does not track, and the
+#   `ve_build_ext` fallback swallows the resulting error and re-runs setup
+#   with no `ext_modules` at all.  `build_ext --inplace` then exits 0 having
+#   built nothing, and the breakage only surfaces much later as accelerated
+#   imports quietly falling back to pure Python.
+#
+# Keep in step with `[build-system].requires` in pyproject.toml.
+setuptools>=69
+setuptools_scm[toml]
+wheel
+cython>=0.29; implementation_name == 'cpython'
+cython>=3.0.0; implementation_name == 'cpython' and python_version >= '3.12'

--- a/requirements/dist.txt
+++ b/requirements/dist.txt
@@ -3,12 +3,17 @@ packaging
 pre-commit
 pydocstyle
 pytest-sugar
-setuptools>=30.3.0,<69.0.0
+# `scripts/build` builds the sdist and wheel through `python -m build`, which
+# needs the frontend itself plus the backend it invokes.  The setuptools pin
+# used to live here as `>=30.3.0,<69.0.0`, which directly contradicted the
+# `setuptools>=69` that pyproject.toml's `[build-system].requires` asks for --
+# an environment built from this file could not run the project's own build.
+build
+-r build.txt
 sphinx-autobuild
 sphinx2rst>=1.0
 tox>=2.3.1
 twine
 vulture
-wheel>=0.29.0
 intervaltree
 importlib-metadata; python_version<'3.8'

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -16,5 +16,13 @@ yarl>=1.0,<2.0
 croniter>=0.3.16
 mypy_extensions
 venusian==3.1.0
-intervaltree
+# >=3.2.0: every earlier release published an sdist only, so installing it had
+# to run its setup.py -- which imported `setuptools.command.test`, removed in
+# setuptools 72.0.0 (2024-07-29).  Since pip and uv provision the newest
+# setuptools into the isolated build environment, installing faust started
+# failing on this dependency the day that release shipped (issue #638).
+# 3.2.0 drops setup.py for a hatchling backend and publishes wheels, so
+# neither half of that can recur.  The floor matters because a lock or
+# constraint file can still resolve an older one.
+intervaltree>=3.2.0
 six

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -27,6 +27,11 @@ twine
 wheel
 intervaltree
 -r requirements.txt
+# setuptools and Cython, so a test environment can build the extension
+# modules in place rather than only through pip's isolated build.  See
+# build.txt: without them `python setup.py build_ext --inplace` either dies
+# on the setuptools import or silently builds nothing.
+-r build.txt
 # mypy, pinned for the same reason as the formatters above: `scripts/check`
 # type-checks the faust package, so the lint job needs it installed.
 -r typecheck.txt

--- a/scripts/build
+++ b/scripts/build
@@ -8,6 +8,17 @@ fi
 
 set -x
 
-${PREFIX}python setup.py sdist bdist_wheel
+# `python -m build`, not `setup.py sdist bdist_wheel`.  The direct invocation
+# needs setuptools importable from the interpreter running it, which a Python
+# 3.12+ environment does not provide unless something installed it (PEP 632
+# removed distutils and `ensurepip` stopped seeding setuptools with it), so it
+# failed with `ModuleNotFoundError: No module named 'setuptools'` before
+# building anything.  `build` provisions the backend itself from
+# `[build-system].requires`.
+#
+# It also names the sdist by the normalized project name
+# (`faust_streaming-*.tar.gz`), which PyPI requires under PEP 625 -- the same
+# reason the release workflow's sdist job already uses it.
+${PREFIX}python -m build
 ${PREFIX}twine check dist/*
 # ${PREFIX}mkdocs build

--- a/setup.py
+++ b/setup.py
@@ -205,8 +205,13 @@ with open("README.md") as readme_file:
 def do_setup(**kwargs):
     setup(
         name="faust-streaming",
+        # No `setup_requires=["setuptools_scm"]` alongside this.  That option
+        # is resolved by `dist.fetch_build_eggs()`, the easy_install-era
+        # installer setuptools now warns about on every invocation, and it is
+        # redundant: setuptools_scm is declared in `[build-system].requires`,
+        # so a PEP 517 build already has it, and requirements/build.txt
+        # provides it for a direct `setup.py` call.
         use_scm_version=True,
-        setup_requires=["setuptools_scm"],
         description=meta["doc"],
         long_description=long_description,
         long_description_content_type="text/markdown",
@@ -217,7 +222,11 @@ def do_setup(**kwargs):
         python_requires=">=3.10.0",
         zip_safe=False,
         install_requires=reqs("requirements.txt"),
-        tests_require=reqs("test.txt"),
+        # No `tests_require=reqs("test.txt")` either.  It only ever fed
+        # `setup.py test` -- the command setuptools 72.0.0 deleted, taking
+        # `setuptools.command.test` with it -- so setuptools has been
+        # reporting it as `Unknown distribution option` and dropping it on the
+        # floor.  requirements/test.txt is what installs the test dependencies.
         extras_require=extras_require(),
         entry_points={
             "console_scripts": [


### PR DESCRIPTION
`USE_CYTHON=1 python setup.py build_ext --inplace` fails in CI with
`ModuleNotFoundError: No module named 'setuptools'`.

Nothing installed setuptools.  `pip install .` looks like it would --
it does read `[build-system].requires` -- but PEP 517 build isolation
provisions those packages into a throwaway environment that is
discarded once the wheel is built, leaving nothing behind on the
interpreter that ran pip.  That was survivable while every build went
through pip.  It stops being survivable the moment something drives
setup.py directly, which building the extensions *in place* requires:
a build into site-packages is never imported by the test suite, since
pytest runs from the repository root and `import faust` resolves to the
source tree.

Python 3.12 is where this turns into an error rather than a latent
assumption.  PEP 632 removed distutils, `ensurepip` stopped seeding
setuptools along with it, and the interpreters `actions/setup-python`
provides now ship with none.

Add requirements/build.txt, mirroring `[build-system].requires`, and
pull it into test.txt so a test environment can build the extensions
rather than only consume them.

Cython belongs in it for a second, quieter reason.  Without Cython
setup.py falls back to compiling pre-generated .c files, which this
repository does not track; `ve_build_ext` then swallows the resulting
error and re-runs setup with no `ext_modules` at all.  `build_ext
--inplace` exits 0 having built nothing, and the failure resurfaces
much later as accelerated imports silently falling back to pure Python.
Verified both halves against a bare interpreter: setuptools missing
fails loudly, setuptools present but Cython missing exits 0 and writes
no .so.

Two more instances of the same assumption, fixed here rather than left
to fail the same way:

- dist.txt pinned `setuptools>=30.3.0,<69.0.0`, which contradicts the
  `setuptools>=69` pyproject.toml asks for -- an environment built from
  that file could not run the project's own build.  It now includes
  build.txt, plus the `build` frontend scripts/build needs.

- scripts/build ran `setup.py sdist bdist_wheel` directly, so it dies
  on the same missing import on any 3.12+ interpreter.  It now uses
  `python -m build`, which provisions the backend itself and names the
  sdist per PEP 625 as PyPI requires -- the same reason the release
  workflow's sdist job already uses it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DwJCsUD7opjiNRKdkQY87F