### PR TITLE
Warn when the pickle codec deserializes message data (CWE-502)

### DIFF
--- a/docs/userguide/models.rst
+++ b/docs/userguide/models.rst
@@ -1014,6 +1014,8 @@ Supported codecs
 * **raw**     - no encoding/serialization (bytes only).
 * **json**    - :mod:`json` with UTF-8 encoding.
 * **pickle**  - :mod:`pickle` with Base64 encoding (not URL-safe).
+* **pickle_restricted** - :mod:`pickle` with Base64 encoding, restricted at
+  load time to a safe allowlist of classes.
 * **binary**  - Base64 encoding (not URL-safe).
 
 Encodings are not URL-safe if the encoded payload cannot be embedded
@@ -1028,7 +1030,31 @@ directly into a URL query parameter.
     anyone able to write to a topic consumed with
     ``value_serializer="pickle"`` (or ``key_serializer="pickle"``) can
     achieve remote code execution. Only enable the pickle codec for
-    topics where every producer is trusted.
+    topics where every producer is trusted. Faust emits a
+    :class:`~faust.exceptions.SecurityWarning` as soon as an app, topic,
+    or model is configured with ``serializer="pickle"``, and again every
+    time a message is actually unpickled.
+
+    If you need pickle's ability to round-trip arbitrary Python objects
+    but cannot fully trust every producer on the topic, use
+    **pickle_restricted** instead. It deserializes with
+    ``faust.serializers.codecs.RestrictedUnpickler``, which only
+    constructs classes from an explicit allowlist
+    (``RestrictedUnpickler.ALLOWED_CLASSES``, covering common stdlib
+    container/value types by default) and raises
+    :exc:`pickle.UnpicklingError` for anything else -- closing off the
+    ``__reduce__``-based gadgets (``os.system``, ``subprocess.Popen``,
+    etc.) that make plain pickle unsafe. Extend ``ALLOWED_CLASSES`` with
+    your own application types as needed:
+
+    .. sourcecode:: python
+
+        from faust.serializers.codecs import RestrictedUnpickler
+
+        RestrictedUnpickler.ALLOWED_CLASSES = {
+            **RestrictedUnpickler.ALLOWED_CLASSES,
+            "myapp.models": frozenset({"Withdrawal", "Order"}),
+        }
 
 Serialization by name
 ---------------------

--- a/docs/userguide/models.rst
+++ b/docs/userguide/models.rst
@@ -1019,6 +1019,17 @@ Supported codecs
 Encodings are not URL-safe if the encoded payload cannot be embedded
 directly into a URL query parameter.
 
+.. warning::
+
+    The **pickle** codec calls :func:`pickle.loads` on the raw message
+    value. :mod:`pickle` is not a safe format for untrusted input: a
+    malicious payload can execute arbitrary code in the worker process
+    at deserialization time. Kafka does not authenticate producers, so
+    anyone able to write to a topic consumed with
+    ``value_serializer="pickle"`` (or ``key_serializer="pickle"``) can
+    achieve remote code execution. Only enable the pickle codec for
+    topics where every producer is trusted.
+
 Serialization by name
 ---------------------
 

--- a/faust/exceptions.py
+++ b/faust/exceptions.py
@@ -7,6 +7,7 @@ __all__ = [
     "FaustWarning",
     "FaustPredicate",
     "SecurityError",
+    "SecurityWarning",
     "NotReady",
     "Skip",
     "AlreadyConfiguredWarning",
@@ -43,6 +44,10 @@ class FaustPredicate(FaustError):
 
 class SecurityError(FaustError):
     """Base-class for security related (high priority) exceptions."""
+
+
+class SecurityWarning(FaustWarning):
+    """Base-class for security related warnings."""
 
 
 class NotReady(FaustPredicate):

--- a/faust/serializers/codecs.py
+++ b/faust/serializers/codecs.py
@@ -7,6 +7,8 @@ Supported codecs
 * **json**    - json with UTF-8 encoding.
 * **yaml**    - YAML (safe version)
 * **pickle**  - pickle with base64 encoding (not urlsafe).
+* **pickle_restricted** - pickle with base64 encoding, restricted at load
+  time to a safe allowlist of classes (see :class:`RestrictedUnpickler`).
 * **binary**  - base64 encoding (not urlsafe).
 
 .. warning::
@@ -17,7 +19,10 @@ Supported codecs
     client able to write to a topic consumed with ``value_serializer=
     "pickle"`` (or ``key_serializer="pickle"``) can achieve remote code
     execution in the worker process. Only use the pickle codec for topics
-    where every producer is trusted.
+    where every producer is trusted. If you need pickle's object support
+    but cannot fully trust every producer, use **pickle_restricted**
+    instead, and extend :attr:`RestrictedUnpickler.ALLOWED_CLASSES` with
+    whatever application types you expect to receive.
 
 Serialization by name
 =====================
@@ -170,11 +175,12 @@ At this point may want to publish this on PyPI to share
 the extension with other Faust users.
 """
 
+import io
 import pickle as _pickle  # nosec B403
 import warnings
 from base64 import b64decode, b64encode
 from types import ModuleType
-from typing import Any, Dict, MutableMapping, Optional, Tuple, Union, cast
+from typing import Any, Dict, FrozenSet, MutableMapping, Optional, Tuple, Union, cast
 
 from mode.utils.compat import want_bytes, want_str
 from mode.utils.imports import load_extension_classes
@@ -289,18 +295,55 @@ class yaml(Codec):
         return want_bytes(_yaml.safe_dump(s))
 
 
+#: Warning shown whenever the unrestricted pickle codec is configured
+#: or used to deserialize a message. See :class:`raw_pickle`.
+UNSAFE_PICKLE_WARNING = (
+    "The pickle codec calls pickle.loads() on message data, which can "
+    "execute arbitrary code if the data does not come from a trusted "
+    "producer. Only use value_serializer/key_serializer='pickle' on "
+    "topics where every producer is trusted. If that cannot be "
+    "guaranteed, use the 'pickle_restricted' codec instead, which limits "
+    "unpickling to a safe allowlist of classes."
+)
+
+
+def uses_unsafe_pickle(codec: CodecArg) -> bool:
+    """Return :const:`True` if ``codec`` resolves to the unrestricted pickle codec.
+
+    This is used to warn as soon as an app/topic/model is *configured*
+    to use ``value_serializer="pickle"``/``key_serializer="pickle"``,
+    rather than waiting for the first message to be deserialized.
+    """
+    if isinstance(codec, str):
+        return any(node == "pickle" for node in codec.split("|"))
+    if isinstance(codec, Codec):
+        return any(isinstance(node, raw_pickle) for node in codec.nodes)
+    return False
+
+
+def warn_if_unsafe_pickle(codec: CodecArg, *, stacklevel: int = 2) -> None:
+    """Emit :class:`~faust.exceptions.SecurityWarning` if ``codec`` uses pickle.
+
+    No-op if ``codec`` does not resolve to the unrestricted pickle codec.
+    """
+    if uses_unsafe_pickle(codec):
+        warnings.warn(UNSAFE_PICKLE_WARNING, SecurityWarning, stacklevel=stacklevel + 1)
+
+
 class raw_pickle(Codec):
-    """:mod:`pickle` serializer with no encoding."""
+    """:mod:`pickle` serializer with no encoding.
+
+    .. danger::
+
+        Calls :func:`pickle.loads` on the raw message value with no
+        restrictions. Never use this (or the ``pickle`` codec that wraps
+        it) on a topic where you cannot fully trust every producer -- see
+        :data:`UNSAFE_PICKLE_WARNING`. Prefer :class:`restricted_pickle`
+        (the ``pickle_restricted`` codec) when in doubt.
+    """
 
     def _loads(self, s: bytes) -> Any:
-        warnings.warn(
-            "The pickle codec calls pickle.loads() on message data, which "
-            "can execute arbitrary code if the data does not come from a "
-            "trusted producer. Only use value_serializer/key_serializer="
-            "'pickle' on topics where every producer is trusted.",
-            SecurityWarning,
-            stacklevel=3,
-        )
+        warnings.warn(UNSAFE_PICKLE_WARNING, SecurityWarning, stacklevel=3)
         return _pickle.loads(s)  # nosec B301
 
     def _dumps(self, obj: Any) -> bytes:
@@ -310,6 +353,88 @@ class raw_pickle(Codec):
 def pickle() -> Codec:
     """:mod:`pickle` serializer with base64 encoding."""
     return raw_pickle() | binary()
+
+
+class RestrictedUnpickler(_pickle.Unpickler):  # type: ignore[misc]
+    """A :class:`pickle.Unpickler` that only constructs allowlisted classes.
+
+    Overrides :meth:`~pickle.Unpickler.find_class` to reject any
+    class/function not listed in :attr:`ALLOWED_CLASSES`, closing off the
+    classic ``__reduce__``-based RCE gadgets (``os.system``,
+    ``subprocess.Popen``, ``builtins.exec``, and friends) that plain
+    :func:`pickle.loads` will happily invoke for untrusted input.
+
+    The default allowlist only covers common stdlib container/value
+    types. Extend :attr:`ALLOWED_CLASSES` (or subclass and override
+    :meth:`find_class`) to allow application-specific types you expect
+    producers to send, for example::
+
+        from faust.serializers.codecs import RestrictedUnpickler
+
+        RestrictedUnpickler.ALLOWED_CLASSES = {
+            **RestrictedUnpickler.ALLOWED_CLASSES,
+            "myapp.models": frozenset({"Withdrawal", "Order"}),
+        }
+    """
+
+    #: Mapping of module name to the class/function names allowed from it.
+    ALLOWED_CLASSES: Dict[str, FrozenSet[str]] = {
+        "builtins": frozenset(
+            {
+                "dict",
+                "list",
+                "set",
+                "frozenset",
+                "tuple",
+                "str",
+                "bytes",
+                "bytearray",
+                "int",
+                "float",
+                "complex",
+                "bool",
+                "object",
+            }
+        ),
+        "collections": frozenset({"OrderedDict", "defaultdict", "deque", "Counter"}),
+        "datetime": frozenset({"datetime", "date", "time", "timedelta", "timezone"}),
+        "decimal": frozenset({"Decimal"}),
+        "uuid": frozenset({"UUID"}),
+    }
+
+    def find_class(self, module: str, name: str) -> Any:
+        """Look up ``module.name``, raising unless it is allowlisted."""
+        allowed = self.ALLOWED_CLASSES.get(module)
+        if allowed is None or name not in allowed:
+            raise _pickle.UnpicklingError(
+                f"Refusing to unpickle disallowed class/function "
+                f"{module}.{name}: not in "
+                "RestrictedUnpickler.ALLOWED_CLASSES. Extend the allowlist "
+                "if this type is expected from your producers, or use the "
+                "unrestricted 'pickle' codec if they are fully trusted."
+            )
+        return super().find_class(module, name)
+
+
+class restricted_pickle(Codec):
+    """:mod:`pickle` serializer with no encoding, restricted to safe classes.
+
+    Like :class:`raw_pickle`, but deserializes using
+    :class:`RestrictedUnpickler` instead of :func:`pickle.loads`, so a
+    payload that tries to construct anything outside the allowlist raises
+    :exc:`pickle.UnpicklingError` instead of running arbitrary code.
+    """
+
+    def _loads(self, s: bytes) -> Any:
+        return RestrictedUnpickler(io.BytesIO(s)).load()
+
+    def _dumps(self, obj: Any) -> bytes:
+        return _pickle.dumps(obj)  # nosec B403
+
+
+def pickle_restricted() -> Codec:
+    """:mod:`pickle` serializer (allowlisted classes) with base64 encoding."""
+    return restricted_pickle() | binary()
 
 
 class binary(Codec):
@@ -336,6 +461,7 @@ class raw(Codec):
 codecs: MutableMapping[str, CodecT] = {
     "json": json(),
     "pickle": pickle(),  # nosec B403
+    "pickle_restricted": pickle_restricted(),
     "binary": binary(),
     "raw": raw(),
     "yaml": yaml(),

--- a/faust/serializers/codecs.py
+++ b/faust/serializers/codecs.py
@@ -378,6 +378,15 @@ class RestrictedUnpickler(_pickle.Unpickler):  # type: ignore[misc]
     """
 
     #: Mapping of module name to the class/function names allowed from it.
+    #:
+    #: ``bytes`` and ``bytearray`` are deliberately excluded even though
+    #: they are safe *value* types: as REDUCE-invoked *callables* they
+    #: each accept a single integer and allocate that many zero bytes
+    #: (``bytearray(2_000_000_000)`` allocates ~2GB from a payload of a
+    #: few dozen bytes), so allowing them here would let an attacker turn
+    #: a tiny message into a memory-exhaustion DoS. Plain bytes/bytearray
+    #: *values* still round-trip fine -- pickle has dedicated opcodes for
+    #: literal bytes/bytearray data that never go through find_class.
     ALLOWED_CLASSES: Dict[str, FrozenSet[str]] = {
         "builtins": frozenset(
             {
@@ -387,8 +396,6 @@ class RestrictedUnpickler(_pickle.Unpickler):  # type: ignore[misc]
                 "frozenset",
                 "tuple",
                 "str",
-                "bytes",
-                "bytearray",
                 "int",
                 "float",
                 "complex",
@@ -429,7 +436,10 @@ class restricted_pickle(Codec):
         return RestrictedUnpickler(io.BytesIO(s)).load()
 
     def _dumps(self, obj: Any) -> bytes:
-        return _pickle.dumps(obj)  # nosec B403
+        # Protocol 5 gives bytearray values their own opcode (BYTEARRAY8)
+        # instead of falling back to a `bytearray(...)` global + REDUCE,
+        # which RestrictedUnpickler refuses (see ALLOWED_CLASSES above).
+        return _pickle.dumps(obj, protocol=5)  # nosec B403
 
 
 def pickle_restricted() -> Codec:

--- a/faust/serializers/codecs.py
+++ b/faust/serializers/codecs.py
@@ -9,6 +9,16 @@ Supported codecs
 * **pickle**  - pickle with base64 encoding (not urlsafe).
 * **binary**  - base64 encoding (not urlsafe).
 
+.. warning::
+
+    The **pickle** codec calls :func:`pickle.loads` on the raw message
+    value, which can execute arbitrary code if the data comes from an
+    untrusted source. Kafka topics do not authenticate producers, so any
+    client able to write to a topic consumed with ``value_serializer=
+    "pickle"`` (or ``key_serializer="pickle"``) can achieve remote code
+    execution in the worker process. Only use the pickle codec for topics
+    where every producer is trusted.
+
 Serialization by name
 =====================
 
@@ -161,6 +171,7 @@ the extension with other Faust users.
 """
 
 import pickle as _pickle  # nosec B403
+import warnings
 from base64 import b64decode, b64encode
 from types import ModuleType
 from typing import Any, Dict, MutableMapping, Optional, Tuple, Union, cast
@@ -168,7 +179,7 @@ from typing import Any, Dict, MutableMapping, Optional, Tuple, Union, cast
 from mode.utils.compat import want_bytes, want_str
 from mode.utils.imports import load_extension_classes
 
-from faust.exceptions import ImproperlyConfigured
+from faust.exceptions import ImproperlyConfigured, SecurityWarning
 from faust.types.codecs import CodecArg, CodecT
 from faust.utils import json as _json
 
@@ -282,6 +293,14 @@ class raw_pickle(Codec):
     """:mod:`pickle` serializer with no encoding."""
 
     def _loads(self, s: bytes) -> Any:
+        warnings.warn(
+            "The pickle codec calls pickle.loads() on message data, which "
+            "can execute arbitrary code if the data does not come from a "
+            "trusted producer. Only use value_serializer/key_serializer="
+            "'pickle' on topics where every producer is trusted.",
+            SecurityWarning,
+            stacklevel=3,
+        )
         return _pickle.loads(s)  # nosec B301
 
     def _dumps(self, obj: Any) -> bytes:

--- a/faust/serializers/registry.py
+++ b/faust/serializers/registry.py
@@ -11,7 +11,7 @@ from faust.exceptions import KeyDecodeError, ValueDecodeError
 from faust.types import K, ModelArg, ModelT, V
 from faust.types.serializers import RegistryT
 
-from .codecs import CodecArg, dumps, loads
+from .codecs import CodecArg, dumps, loads, warn_if_unsafe_pickle
 
 __all__ = ["Registry"]
 
@@ -33,6 +33,8 @@ class Registry(RegistryT):
     ) -> None:
         self.key_serializer = key_serializer
         self.value_serializer = value_serializer
+        warn_if_unsafe_pickle(key_serializer)
+        warn_if_unsafe_pickle(value_serializer)
 
     def loads_key(
         self,

--- a/faust/serializers/schemas.py
+++ b/faust/serializers/schemas.py
@@ -64,14 +64,18 @@ class Schema(SchemaT[KT, VT]):
             self.value_type = value_type
         if key_serializer is not None:
             self.key_serializer = key_serializer
-            warn_if_unsafe_pickle(key_serializer)
         if value_serializer is not None:
             self.value_serializer = value_serializer
-            warn_if_unsafe_pickle(value_serializer)
         if self.key_serializer is None and key_type:
             self.key_serializer = _model_serializer(key_type)
         if self.value_serializer is None and value_type:
             self.value_serializer = _model_serializer(value_type)
+        # Check after model-derived defaults are resolved above, so a
+        # serializer inherited from key_type/value_type (e.g. a Record
+        # declared with `serializer="pickle"`) is also caught, not just
+        # an explicit key_serializer/value_serializer argument.
+        warn_if_unsafe_pickle(self.key_serializer)
+        warn_if_unsafe_pickle(self.value_serializer)
         if allow_empty is not None:
             self.allow_empty = allow_empty
 

--- a/faust/serializers/schemas.py
+++ b/faust/serializers/schemas.py
@@ -3,6 +3,7 @@ from contextlib import suppress
 from typing import Any, Awaitable, Callable, Optional, Tuple, cast
 
 from faust.exceptions import KeyDecodeError, ValueDecodeError
+from faust.serializers.codecs import warn_if_unsafe_pickle
 from faust.types.app import AppT
 from faust.types.codecs import CodecArg
 from faust.types.core import K, OpenHeadersArg, V
@@ -63,8 +64,10 @@ class Schema(SchemaT[KT, VT]):
             self.value_type = value_type
         if key_serializer is not None:
             self.key_serializer = key_serializer
+            warn_if_unsafe_pickle(key_serializer)
         if value_serializer is not None:
             self.value_serializer = value_serializer
+            warn_if_unsafe_pickle(value_serializer)
         if self.key_serializer is None and key_type:
             self.key_serializer = _model_serializer(key_type)
         if self.value_serializer is None and value_type:

--- a/tests/unit/serializers/test_codecs.py
+++ b/tests/unit/serializers/test_codecs.py
@@ -7,7 +7,7 @@ from hypothesis import given
 from hypothesis.strategies import binary, dictionaries, text
 from mode.utils.compat import want_str
 
-from faust.exceptions import ImproperlyConfigured
+from faust.exceptions import ImproperlyConfigured, SecurityWarning
 from faust.serializers.codecs import (
     Codec,
     binary as _binary,
@@ -93,3 +93,9 @@ def test_raw():
     bits = get_codec("raw").dumps("foo")
     assert isinstance(bits, bytes)
     assert get_codec("raw").loads(bits) == b"foo"
+
+
+def test_pickle_loads_warns_of_security_risk() -> None:
+    payload = dumps("pickle", DATA)
+    with pytest.warns(SecurityWarning):
+        assert loads("pickle", payload) == DATA

--- a/tests/unit/serializers/test_codecs.py
+++ b/tests/unit/serializers/test_codecs.py
@@ -1,4 +1,6 @@
 import base64
+import pickle
+import warnings
 from typing import Mapping
 from unittest.mock import patch
 
@@ -10,6 +12,7 @@ from mode.utils.compat import want_str
 from faust.exceptions import ImproperlyConfigured, SecurityWarning
 from faust.serializers.codecs import (
     Codec,
+    RestrictedUnpickler,
     binary as _binary,
     codecs,
     dumps,
@@ -17,7 +20,11 @@ from faust.serializers.codecs import (
     json,
     loads,
     register,
+    uses_unsafe_pickle,
+    warn_if_unsafe_pickle,
 )
+from faust.serializers.registry import Registry
+from faust.serializers.schemas import Schema
 from faust.utils import json as _json
 
 DATA = {"a": 1, "b": "string", 1: 2}
@@ -32,7 +39,7 @@ def test_interface():
     assert s.__or__(1) is NotImplemented
 
 
-@pytest.mark.parametrize("codec", ["json", "pickle", "yaml"])
+@pytest.mark.parametrize("codec", ["json", "pickle", "pickle_restricted", "yaml"])
 def test_json_subset(codec: str) -> None:
     if codec == "json":
         # special exception for json since integers can be serialized
@@ -99,3 +106,89 @@ def test_pickle_loads_warns_of_security_risk() -> None:
     payload = dumps("pickle", DATA)
     with pytest.warns(SecurityWarning):
         assert loads("pickle", payload) == DATA
+
+
+class _EvilPayload:
+    def __reduce__(self):
+        return (eval, ("1 + 1",))
+
+
+def test_pickle_restricted_blocks_disallowed_classes() -> None:
+    payload = dumps("pickle_restricted", _EvilPayload())
+    with pytest.raises(pickle.UnpicklingError):
+        loads("pickle_restricted", payload)
+
+
+def test_pickle_restricted_does_not_warn() -> None:
+    payload = dumps("pickle_restricted", DATA)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SecurityWarning)
+        assert loads("pickle_restricted", payload) == DATA
+
+
+class _Point:
+    def __init__(self, x, y):
+        self.x, self.y = x, y
+
+    def __reduce__(self):
+        return (self.__class__, (self.x, self.y))
+
+
+def test_restricted_unpickler_allows_extending_allowlist() -> None:
+    original = dict(RestrictedUnpickler.ALLOWED_CLASSES)
+    try:
+        payload = dumps("pickle_restricted", _Point(1, 2))
+        with pytest.raises(pickle.UnpicklingError):
+            loads("pickle_restricted", payload)
+
+        RestrictedUnpickler.ALLOWED_CLASSES = {
+            **RestrictedUnpickler.ALLOWED_CLASSES,
+            __name__: frozenset({"_Point"}),
+        }
+        point = loads("pickle_restricted", payload)
+        assert (point.x, point.y) == (1, 2)
+    finally:
+        RestrictedUnpickler.ALLOWED_CLASSES = original
+
+
+@pytest.mark.parametrize(
+    "codec,expected",
+    [
+        ("pickle", True),
+        ("pickle|binary", True),
+        ("json", False),
+        ("pickle_restricted", False),
+        (None, False),
+        (get_codec("pickle"), True),
+        (get_codec("pickle_restricted"), False),
+    ],
+)
+def test_uses_unsafe_pickle(codec, expected) -> None:
+    assert uses_unsafe_pickle(codec) is expected
+
+
+def test_warn_if_unsafe_pickle() -> None:
+    with pytest.warns(SecurityWarning):
+        warn_if_unsafe_pickle("pickle")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SecurityWarning)
+        warn_if_unsafe_pickle("json")  # should not raise/warn
+
+
+def test_registry_warns_when_configured_with_pickle() -> None:
+    with pytest.warns(SecurityWarning):
+        Registry(value_serializer="pickle")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SecurityWarning)
+        Registry(value_serializer="pickle_restricted")
+
+
+def test_schema_warns_when_configured_with_pickle() -> None:
+    with pytest.warns(SecurityWarning):
+        Schema(value_serializer="pickle")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SecurityWarning)
+        Schema(value_serializer="pickle_restricted")

--- a/tests/unit/serializers/test_codecs.py
+++ b/tests/unit/serializers/test_codecs.py
@@ -176,6 +176,70 @@ def test_warn_if_unsafe_pickle() -> None:
         warn_if_unsafe_pickle("json")  # should not raise/warn
 
 
+def test_pickle_restricted_round_trips_bytes_and_bytearray() -> None:
+    val = {"a": bytes(b"hello"), "b": bytearray(b"world")}
+    payload = dumps("pickle_restricted", val)
+    assert loads("pickle_restricted", payload) == val
+
+
+class _BytesAllocationGadget:
+    def __reduce__(self):
+        return (bytes, (2_000_000_000,))
+
+
+class _ByteArrayAllocationGadget:
+    def __reduce__(self):
+        return (bytearray, (2_000_000_000,))
+
+
+def test_pickle_restricted_blocks_bytes_allocation_gadget() -> None:
+    payload = dumps("pickle_restricted", _BytesAllocationGadget())
+    with pytest.raises(pickle.UnpicklingError):
+        loads("pickle_restricted", payload)
+
+
+def test_pickle_restricted_blocks_bytearray_allocation_gadget() -> None:
+    payload = dumps("pickle_restricted", _ByteArrayAllocationGadget())
+    with pytest.raises(pickle.UnpicklingError):
+        loads("pickle_restricted", payload)
+
+
+class _PickleOptions:
+    serializer = "pickle"
+
+
+class _PickleModelType:
+    _options = _PickleOptions()
+
+
+class _JsonOptions:
+    serializer = "json"
+
+
+class _JsonModelType:
+    _options = _JsonOptions()
+
+
+def test_schema_warns_when_value_type_derives_pickle_serializer() -> None:
+    # No explicit value_serializer -- the schema must derive it from
+    # value_type._options.serializer and still warn.
+    with pytest.warns(SecurityWarning):
+        Schema(value_type=_PickleModelType)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SecurityWarning)
+        Schema(value_type=_JsonModelType)
+
+
+def test_schema_warns_when_key_type_derives_pickle_serializer() -> None:
+    with pytest.warns(SecurityWarning):
+        Schema(key_type=_PickleModelType)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SecurityWarning)
+        Schema(key_type=_JsonModelType)
+
+
 def test_registry_warns_when_configured_with_pickle() -> None:
     with pytest.warns(SecurityWarning):
         Registry(value_serializer="pickle")


### PR DESCRIPTION
The built-in pickle codec calls pickle.loads() directly on raw Kafka
message bytes. Kafka does not authenticate producers, so any client able
to write to a topic consumed with value_serializer/key_serializer=
'pickle' can trigger arbitrary code execution in the worker process via
a crafted payload.

Since pickle is a documented, first-party codec and removing it would be
a breaking change, add a SecurityWarning raised on every pickle _loads()
call (Python's default warning filter dedupes by call site, so this
doesn't spam logs) and document the risk in the codecs module docstring
and user guide.