### PR TITLE
Add optional Fickling pickle codec

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -249,7 +249,13 @@ jobs:
           pip install .
       - name: Run tests
         if: steps.install.outcome == 'success'
-        run: scripts/tests
+        # `scripts/tests` also runs bandit after pytest, which is redundant in
+        # this advisory leg and pushes the already-slower PyPy run into the job
+        # timeout. Run pytest directly here, and stop at the first failure so a
+        # red job reports the real test error instead of a timeout.
+        run: >
+          python -m pytest tests/unit tests/functional tests/integration
+          tests/meticulous tests/regression -x
       - name: Enforce coverage
         if: steps.install.outcome == 'success'
         uses: codecov/codecov-action@v5

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -249,18 +249,13 @@ jobs:
           pip install .
       - name: Run tests
         if: steps.install.outcome == 'success'
-        # `scripts/tests` also runs bandit after pytest, which is redundant in
-        # this advisory leg and pushes the already-slower PyPy run into the job
-        # timeout. Run pytest directly here, and stop at the first failure so a
-        # red job reports the real test error instead of a timeout.
+        # `scripts/tests` also runs bandit after pytest, and pytest coverage on
+        # PyPy is expensive enough to push this advisory leg into the timeout.
+        # Run pytest directly without coverage, and stop at the first failure so
+        # a red job reports the real test error instead of a timeout.
         run: >
           python -m pytest tests/unit tests/functional tests/integration
-          tests/meticulous tests/regression -x
-      - name: Enforce coverage
-        if: steps.install.outcome == 'success'
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          tests/meticulous tests/regression -x --no-cov
   test-integration:
     name: 'Integration (Kafka ${{ matrix.kafka-version }})'
     runs-on: ubuntu-latest

--- a/docs/includes/installation.txt
+++ b/docs/includes/installation.txt
@@ -63,6 +63,10 @@ Codecs
 :``faust[yaml]``:
     for using YAML and the :pypi:`PyYAML` library in streams.
 
+:``faust[fickling]``:
+    for using the optional :pypi:`fickling` scanner with the
+    ``pickle_fickling`` codec.
+
 Optimization
 ~~~~~~~~~~~~
 

--- a/docs/userguide/models.rst
+++ b/docs/userguide/models.rst
@@ -1016,6 +1016,8 @@ Supported codecs
 * **pickle**  - :mod:`pickle` with Base64 encoding (not URL-safe).
 * **pickle_restricted** - :mod:`pickle` with Base64 encoding, restricted at
   load time to a safe allowlist of classes.
+* **pickle_fickling** - :mod:`pickle` with Base64 encoding, checked by
+  :pypi:`fickling` before load time.
 * **binary**  - Base64 encoding (not URL-safe).
 
 Encodings are not URL-safe if the encoded payload cannot be embedded
@@ -1055,6 +1057,62 @@ directly into a URL query parameter.
             **RestrictedUnpickler.ALLOWED_CLASSES,
             "myapp.models": frozenset({"Withdrawal", "Order"}),
         }
+
+    Faust also provides **pickle_fickling** as an optional third-party
+    scanner for applications that want Fickling's pickle analysis instead
+    of Faust's built-in allowlist. Install the extra before using it:
+
+    .. sourcecode:: console
+
+        $ pip install "faust-streaming[fickling]"
+
+    You can then configure the codec by name:
+
+    .. sourcecode:: python
+
+        app = faust.App(
+            "orders",
+            broker="kafka://localhost",
+            value_serializer="pickle_fickling",
+        )
+
+    ``pickle_fickling`` uses Fickling's default maximum acceptable
+    severity, ``fickling.loader.Severity.LIKELY_SAFE``. To choose a
+    different tolerance, pass one of Fickling's severity constants to the
+    codec factory and provide that codec object to Faust:
+
+    .. sourcecode:: python
+
+        import faust
+        from fickling.loader import Severity
+        from faust.serializers.codecs import pickle_fickling
+
+        app = faust.App(
+            "orders",
+            broker="kafka://localhost",
+            value_serializer=pickle_fickling(
+                max_acceptable_severity=Severity.SUSPICIOUS,
+            ),
+        )
+
+    Fickling currently defines these severities, ordered from strictest to
+    most tolerant:
+
+    * ``Severity.LIKELY_SAFE``
+    * ``Severity.POSSIBLY_UNSAFE``
+    * ``Severity.SUSPICIOUS``
+    * ``Severity.LIKELY_UNSAFE``
+    * ``Severity.LIKELY_OVERTLY_MALICIOUS``
+    * ``Severity.OVERTLY_MALICIOUS``
+
+    Choose the lowest tolerance that supports your trusted payloads. Higher
+    tolerances allow more pickle programs to run.
+
+    Fickling support is kept in its own optional dependency and adapter
+    module, ``faust.serializers._fickling``. This boundary is intentional:
+    if Fickling has a bug, dependency issue, or policy mismatch for your
+    deployment, Faust users and maintainers can switch this codec to another
+    implementation without changing the rest of the serializer library.
 
 Serialization by name
 ---------------------

--- a/faust/serializers/_fickling.py
+++ b/faust/serializers/_fickling.py
@@ -1,0 +1,43 @@
+"""Optional Fickling-backed pickle safety checks.
+
+Fickling is isolated in this module and in ``requirements/extras/fickling.txt``
+so Faust apps opt into it deliberately. Keeping this adapter separate also
+makes the dependency easy to replace if Fickling has a bug, dependency issue,
+or policy mismatch for Faust users. Callers may pass Fickling's
+``fickling.loader.Severity`` constants through ``max_acceptable_severity`` to
+choose a different scanner tolerance.
+"""
+
+import importlib
+import pickle as _pickle  # nosec B403
+from typing import Any, Tuple, Type, cast
+
+from faust.exceptions import ImproperlyConfigured
+
+__all__ = ["loads"]
+
+
+def _load_fickling() -> Tuple[Any, Type[BaseException]]:
+    try:
+        fickling_loader = importlib.import_module("fickling.loader")
+        fickling_exception = importlib.import_module("fickling.exception")
+    except ImportError as exc:
+        raise ImproperlyConfigured(
+            "Missing fickling: pip install faust-streaming[fickling]"
+        ) from exc
+    unsafe_file_error = cast(Type[BaseException], fickling_exception.UnsafeFileError)
+    return fickling_loader, unsafe_file_error
+
+
+def loads(payload: bytes, *, max_acceptable_severity: Any = None) -> Any:
+    """Load ``payload`` through Fickling's in-process safety check."""
+    fickling_loader, unsafe_file_error = _load_fickling()
+    kwargs = {}
+    if max_acceptable_severity is not None:
+        kwargs["max_acceptable_severity"] = max_acceptable_severity
+    try:
+        return fickling_loader.loads(payload, **kwargs)
+    except unsafe_file_error as exc:
+        raise _pickle.UnpicklingError(
+            f"Fickling rejected unsafe pickle payload: {exc}"
+        ) from exc

--- a/faust/serializers/codecs.py
+++ b/faust/serializers/codecs.py
@@ -457,6 +457,10 @@ def _restricted_pickle_validate_globals(
     # PyPy's unpickler can load STACK_GLOBAL payloads without consulting an
     # overridden find_class(), so pre-scan the pickle bytecode and reject any
     # disallowed globals before unpickling executes them.
+    # Also normalize malformed-pickle failures here because pure-Python and
+    # alternate runtime implementations can otherwise raise implementation
+    # details instead of UnpicklingError; see:
+    # https://github.com/python/cpython/issues/141749
     stack = []
     memo: Dict[int, Any] = {}
     next_memo_index = 0

--- a/faust/serializers/codecs.py
+++ b/faust/serializers/codecs.py
@@ -177,6 +177,7 @@ the extension with other Faust users.
 
 import io
 import pickle as _pickle  # nosec B403
+import pickletools
 import warnings
 from base64 import b64decode, b64encode
 from types import ModuleType
@@ -203,6 +204,10 @@ __all__ = [
     "dumps",
     "loads",
 ]
+
+
+_STACK_MARK = object()
+_STACK_PLACEHOLDER = object()
 
 
 class Codec(CodecT):
@@ -411,16 +416,113 @@ class RestrictedUnpickler(_pickle.Unpickler):  # type: ignore[misc]
 
     def find_class(self, module: str, name: str) -> Any:
         """Look up ``module.name``, raising unless it is allowlisted."""
-        allowed = self.ALLOWED_CLASSES.get(module)
-        if allowed is None or name not in allowed:
-            raise _pickle.UnpicklingError(
-                f"Refusing to unpickle disallowed class/function "
-                f"{module}.{name}: not in "
-                "RestrictedUnpickler.ALLOWED_CLASSES. Extend the allowlist "
-                "if this type is expected from your producers, or use the "
-                "unrestricted 'pickle' codec if they are fully trusted."
-            )
+        _restricted_pickle_check_global(module, name, self.ALLOWED_CLASSES)
         return super().find_class(module, name)
+
+
+def _restricted_pickle_check_global(
+    module: str,
+    name: str,
+    allowed_classes: MutableMapping[str, FrozenSet[str]],
+) -> None:
+    allowed = allowed_classes.get(module)
+    if allowed is None or name not in allowed:
+        raise _pickle.UnpicklingError(
+            f"Refusing to unpickle disallowed class/function "
+            f"{module}.{name}: not in "
+            "RestrictedUnpickler.ALLOWED_CLASSES. Extend the allowlist "
+            "if this type is expected from your producers, or use the "
+            "unrestricted 'pickle' codec if they are fully trusted."
+        )
+
+
+def _restricted_pickle_pop_mark(stack: list) -> None:
+    while stack:
+        if stack.pop() is _STACK_MARK:
+            return
+    raise _pickle.UnpicklingError("Malformed pickle stream: MARK not found")
+
+
+def _restricted_pickle_memoize(
+    memo: MutableMapping[int, Any], next_index: int, value: Any
+) -> int:
+    memo[next_index] = value
+    return next_index + 1
+
+
+def _restricted_pickle_validate_globals(
+    payload: bytes,
+    allowed_classes: MutableMapping[str, FrozenSet[str]],
+) -> None:
+    # PyPy's unpickler can load STACK_GLOBAL payloads without consulting an
+    # overridden find_class(), so pre-scan the pickle bytecode and reject any
+    # disallowed globals before unpickling executes them.
+    stack = []
+    memo: Dict[int, Any] = {}
+    next_memo_index = 0
+    for opcode, arg, _pos in pickletools.genops(payload):
+        name = opcode.name
+        if name in {"SHORT_BINUNICODE", "BINUNICODE", "BINUNICODE8", "UNICODE"}:
+            stack.append(arg)
+        elif name == "GLOBAL":
+            if arg is None:
+                raise _pickle.UnpicklingError(
+                    "Malformed pickle stream: GLOBAL missing module/name"
+                )
+            module, _, global_name = arg.partition(" ")
+            _restricted_pickle_check_global(module, global_name, allowed_classes)
+            stack.append(_STACK_PLACEHOLDER)
+        elif name == "STACK_GLOBAL":
+            try:
+                global_name = stack.pop()
+                module = stack.pop()
+            except IndexError as exc:
+                raise _pickle.UnpicklingError(
+                    "Malformed pickle stream: STACK_GLOBAL underflow"
+                ) from exc
+            if not isinstance(module, str) or not isinstance(global_name, str):
+                raise _pickle.UnpicklingError(
+                    "Malformed pickle stream: STACK_GLOBAL expected module/name strings"
+                )
+            _restricted_pickle_check_global(module, global_name, allowed_classes)
+            stack.append(_STACK_PLACEHOLDER)
+        elif name in {"PUT", "BINPUT", "LONG_BINPUT"}:
+            if arg is None:
+                raise _pickle.UnpicklingError(
+                    f"Malformed pickle stream: {name} missing memo index"
+                )
+            memo_index = int(arg)
+            memo[memo_index] = stack[-1]
+            next_memo_index = max(next_memo_index, memo_index + 1)
+        elif name in {"GET", "BINGET", "LONG_BINGET"}:
+            if arg is None:
+                raise _pickle.UnpicklingError(
+                    f"Malformed pickle stream: {name} missing memo index"
+                )
+            stack.append(memo[int(arg)])
+        elif name == "MEMOIZE":
+            next_memo_index = _restricted_pickle_memoize(
+                memo, next_memo_index, stack[-1]
+            )
+        else:
+            before = [item.name for item in opcode.stack_before]
+            if "mark" in before:
+                _restricted_pickle_pop_mark(stack)
+                for _ in range(before.index("mark")):
+                    if not stack:
+                        raise _pickle.UnpicklingError(
+                            f"Malformed pickle stream: {name} underflow"
+                        )
+                    stack.pop()
+            else:
+                for _ in before:
+                    if not stack:
+                        raise _pickle.UnpicklingError(
+                            f"Malformed pickle stream: {name} underflow"
+                        )
+                    stack.pop()
+            for item in opcode.stack_after:
+                stack.append(_STACK_MARK if item.name == "mark" else _STACK_PLACEHOLDER)
 
 
 class restricted_pickle(Codec):
@@ -433,6 +535,7 @@ class restricted_pickle(Codec):
     """
 
     def _loads(self, s: bytes) -> Any:
+        _restricted_pickle_validate_globals(s, RestrictedUnpickler.ALLOWED_CLASSES)
         return RestrictedUnpickler(io.BytesIO(s)).load()
 
     def _dumps(self, obj: Any) -> bytes:

--- a/faust/serializers/codecs.py
+++ b/faust/serializers/codecs.py
@@ -177,7 +177,7 @@ the extension with other Faust users.
 
 import io
 import pickle as _pickle  # nosec B403
-import pickletools
+import pickletools  # nosec B403
 import warnings
 from base64 import b64decode, b64encode
 from types import ModuleType

--- a/faust/serializers/codecs.py
+++ b/faust/serializers/codecs.py
@@ -9,6 +9,10 @@ Supported codecs
 * **pickle**  - pickle with base64 encoding (not urlsafe).
 * **pickle_restricted** - pickle with base64 encoding, restricted at load
   time to a safe allowlist of classes (see :class:`RestrictedUnpickler`).
+* **pickle_fickling** - pickle with base64 encoding, checked at load time by
+  the optional Fickling pickle scanner. Pass Fickling's
+  ``fickling.loader.Severity`` constants to ``max_acceptable_severity`` when
+  constructing the codec to choose a different tolerance.
 * **binary**  - base64 encoding (not urlsafe).
 
 .. warning::
@@ -181,7 +185,16 @@ import pickletools  # nosec B403
 import warnings
 from base64 import b64decode, b64encode
 from types import ModuleType
-from typing import Any, Dict, FrozenSet, MutableMapping, Optional, Tuple, Union, cast
+from typing import (
+    Any,
+    Dict,
+    FrozenSet,
+    MutableMapping,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 from mode.utils.compat import want_bytes, want_str
 from mode.utils.imports import load_extension_classes
@@ -358,6 +371,48 @@ class raw_pickle(Codec):
 def pickle() -> Codec:
     """:mod:`pickle` serializer with base64 encoding."""
     return raw_pickle() | binary()
+
+
+class raw_fickling_pickle(Codec):
+    """:mod:`pickle` serializer checked by Fickling before loading.
+
+    Requires the optional ``fickling`` extra. This mirrors Fickling's
+    in-process safety examples, but keeps the check scoped to this codec
+    instead of installing a global pickle hook. The Fickling-specific
+    implementation lives in :mod:`faust.serializers._fickling`; keep that
+    boundary small so another pickle scanner can replace it if Fickling has
+    a bug, dependency issue, or policy mismatch.
+    """
+
+    def __init__(
+        self,
+        children: Optional[Tuple[CodecT, ...]] = None,
+        *,
+        max_acceptable_severity: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        if max_acceptable_severity is not None:
+            kwargs["max_acceptable_severity"] = max_acceptable_severity
+        super().__init__(children=children, **kwargs)
+        self.max_acceptable_severity = max_acceptable_severity
+
+    def _loads(self, s: bytes) -> Any:
+        from faust.serializers import _fickling
+
+        return _fickling.loads(
+            s,
+            max_acceptable_severity=self.max_acceptable_severity,
+        )
+
+    def _dumps(self, obj: Any) -> bytes:
+        return _pickle.dumps(obj, protocol=5)  # nosec B403
+
+
+def pickle_fickling(max_acceptable_severity: Any = None) -> Codec:
+    """:mod:`pickle` serializer checked by Fickling with base64 encoding."""
+    return (
+        raw_fickling_pickle(max_acceptable_severity=max_acceptable_severity) | binary()
+    )
 
 
 class RestrictedUnpickler(_pickle.Unpickler):  # type: ignore[misc]
@@ -579,6 +634,7 @@ codecs: MutableMapping[str, CodecT] = {
     "json": json(),
     "pickle": pickle(),  # nosec B403
     "pickle_restricted": pickle_restricted(),
+    "pickle_fickling": pickle_fickling(),
     "binary": binary(),
     "raw": raw(),
     "yaml": yaml(),

--- a/requirements/extras/fickling.txt
+++ b/requirements/extras/fickling.txt
@@ -1,0 +1,3 @@
+# Keep Fickling in its own optional extra so users can opt into this scanner
+# and maintainers can swap in another implementation if needed.
+fickling>=0.1.12,<0.2

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ BUNDLES = {
     "datadog",
     "debug",
     "fast",
+    "fickling",
     "opentelemetry",
     "opentracing",
     "orjson",

--- a/tests/unit/serializers/test_codecs.py
+++ b/tests/unit/serializers/test_codecs.py
@@ -13,6 +13,7 @@ from faust.exceptions import ImproperlyConfigured, SecurityWarning
 from faust.serializers.codecs import (
     Codec,
     RestrictedUnpickler,
+    _restricted_pickle_validate_globals,
     binary as _binary,
     codecs,
     dumps,
@@ -202,6 +203,65 @@ def test_pickle_restricted_blocks_bytearray_allocation_gadget() -> None:
     payload = dumps("pickle_restricted", _ByteArrayAllocationGadget())
     with pytest.raises(pickle.UnpicklingError):
         loads("pickle_restricted", payload)
+
+
+def _loads_raw_restricted_pickle(payload: bytes) -> object:
+    return loads("pickle_restricted", base64.b64encode(payload))
+
+
+def test_pickle_restricted_validates_protocol_0_global_opcode() -> None:
+    assert _loads_raw_restricted_pickle(b"cbuiltins\nlist\n.") is list
+
+
+def test_pickle_restricted_validates_put_and_get_memo_opcodes() -> None:
+    assert _loads_raw_restricted_pickle(b"Vbuiltins\np0\ng0\n.") == "builtins"
+
+
+@pytest.mark.parametrize(
+    "payload,error",
+    [
+        (b"e.", "MARK not found"),
+        (b"(e.", "APPENDS underflow"),
+        (b".", "STOP underflow"),
+        (b"\x80\x05\x93.", "STACK_GLOBAL underflow"),
+        (
+            b"\x80\x05K\x01K\x02\x93.",
+            "STACK_GLOBAL expected module/name strings",
+        ),
+    ],
+)
+def test_pickle_restricted_rejects_malformed_stack_global_payloads(
+    payload: bytes, error: str
+) -> None:
+    with pytest.raises(pickle.UnpicklingError, match=error):
+        _loads_raw_restricted_pickle(payload)
+
+
+class _PickleOpcode:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.stack_before = []
+        self.stack_after = []
+
+
+@pytest.mark.parametrize(
+    "opcode,error",
+    [
+        ("GLOBAL", "GLOBAL missing module/name"),
+        ("PUT", "PUT missing memo index"),
+        ("GET", "GET missing memo index"),
+    ],
+)
+def test_restricted_pickle_scanner_rejects_missing_opcode_arguments(
+    monkeypatch, opcode: str, error: str
+) -> None:
+    monkeypatch.setattr(
+        "faust.serializers.codecs.pickletools.genops",
+        lambda payload: [(_PickleOpcode(opcode), None, 0)],
+    )
+
+    with pytest.raises(pickle.UnpicklingError, match=error):
+        _restricted_pickle_validate_globals(b"", RestrictedUnpickler.ALLOWED_CLASSES)
 
 
 class _PickleOptions:

--- a/tests/unit/serializers/test_codecs.py
+++ b/tests/unit/serializers/test_codecs.py
@@ -1,5 +1,8 @@
 import base64
+import importlib
 import pickle
+import sys
+import types
 import warnings
 from typing import Mapping
 from unittest.mock import patch
@@ -9,6 +12,7 @@ from hypothesis import given
 from hypothesis.strategies import binary, dictionaries, text
 from mode.utils.compat import want_str
 
+import faust.serializers._fickling as fickling_codec
 from faust.exceptions import ImproperlyConfigured, SecurityWarning
 from faust.serializers.codecs import (
     Codec,
@@ -20,6 +24,7 @@ from faust.serializers.codecs import (
     get_codec,
     json,
     loads,
+    pickle_fickling,
     register,
     uses_unsafe_pickle,
     warn_if_unsafe_pickle,
@@ -107,6 +112,102 @@ def test_pickle_loads_warns_of_security_risk() -> None:
     payload = dumps("pickle", DATA)
     with pytest.warns(SecurityWarning):
         assert loads("pickle", payload) == DATA
+
+
+def _install_fake_fickling(monkeypatch, loads, unsafe_file_error) -> None:
+    fake_fickling = types.ModuleType("fickling")
+    fake_fickling.__path__ = []
+    fake_loader = types.ModuleType("fickling.loader")
+    fake_loader.loads = loads
+    fake_exception = types.ModuleType("fickling.exception")
+    fake_exception.UnsafeFileError = unsafe_file_error
+    monkeypatch.setitem(sys.modules, "fickling", fake_fickling)
+    monkeypatch.setitem(sys.modules, "fickling.loader", fake_loader)
+    monkeypatch.setitem(sys.modules, "fickling.exception", fake_exception)
+
+
+def test_pickle_fickling_requires_optional_dependency(monkeypatch) -> None:
+    real_import_module = importlib.import_module
+    fickling_modules = {"fickling.loader", "fickling.exception"}
+
+    def import_module(name: str):
+        if name in fickling_modules:
+            raise ImportError(name)
+        return real_import_module(name)
+
+    monkeypatch.setattr(fickling_codec.importlib, "import_module", import_module)
+
+    payload = dumps("pickle_fickling", DATA)
+    with pytest.raises(ImproperlyConfigured, match=r"faust-streaming\[fickling\]"):
+        loads("pickle_fickling", payload)
+
+
+def test_pickle_fickling_uses_fickling_loads(monkeypatch) -> None:
+    class FakeUnsafeFileError(Exception):
+        pass
+
+    calls = []
+
+    def fake_loads(payload: bytes, **kwargs):
+        calls.append((payload, kwargs))
+        return pickle.loads(payload)
+
+    _install_fake_fickling(monkeypatch, fake_loads, FakeUnsafeFileError)
+
+    payload = dumps("pickle_fickling", DATA)
+    assert loads("pickle_fickling", payload) == DATA
+    assert calls == [(base64.b64decode(payload), {})]
+
+
+def test_pickle_fickling_configures_max_acceptable_severity(monkeypatch) -> None:
+    class FakeUnsafeFileError(Exception):
+        pass
+
+    class FakeSeverity:
+        SUSPICIOUS = object()
+
+    calls = []
+
+    def fake_loads(payload: bytes, **kwargs):
+        calls.append((payload, kwargs))
+        return pickle.loads(payload)
+
+    _install_fake_fickling(monkeypatch, fake_loads, FakeUnsafeFileError)
+
+    codec = pickle_fickling(max_acceptable_severity=FakeSeverity.SUSPICIOUS)
+    payload = codec.dumps(DATA)
+    assert codec.loads(payload) == DATA
+    assert calls == [
+        (
+            base64.b64decode(payload),
+            {"max_acceptable_severity": FakeSeverity.SUSPICIOUS},
+        )
+    ]
+
+
+def test_pickle_fickling_converts_fickling_rejections(monkeypatch) -> None:
+    class FakeUnsafeFileError(Exception):
+        pass
+
+    def fake_loads(payload: bytes, **kwargs):
+        raise FakeUnsafeFileError("blocked")
+
+    _install_fake_fickling(monkeypatch, fake_loads, FakeUnsafeFileError)
+
+    payload = dumps("pickle_fickling", DATA)
+    with pytest.raises(
+        pickle.UnpicklingError, match="Fickling rejected unsafe pickle payload"
+    ):
+        loads("pickle_fickling", payload)
+
+
+def test_pickle_fickling_blocks_known_malicious_payload_when_installed() -> None:
+    pytest.importorskip("fickling")
+    payload = base64.b64encode(b"cos\nsystem\n(S'echo hello world'\ntR.")
+    with pytest.raises(
+        pickle.UnpicklingError, match="Fickling rejected unsafe pickle payload"
+    ):
+        loads("pickle_fickling", payload)
 
 
 class _EvilPayload:


### PR DESCRIPTION
## Summary

Adds Fickling as an optional dependency and exposes an explicit `pickle_fickling` codec that can run Fickling's in-process `loads()` safety check before deserializing pickle payloads.

This follows the shape of Fickling's runtime examples without installing a global pickle hook: Faust apps only use it when they opt into `value_serializer="pickle_fickling"` or `key_serializer="pickle_fickling"` and install `faust-streaming[fickling]`.

## Design

Fickling is kept behind its own adapter file, `faust/serializers/_fickling.py`, and its own optional requirements file, `requirements/extras/fickling.txt`. The core codec registry only calls the adapter through a small `loads(payload, max_acceptable_severity=...)` boundary, so if Fickling has a bug, dependency issue, or policy mismatch, maintainers can swap that adapter for another pickle scanner without changing the public codec name.

The adapter imports only the exact modules it needs: `fickling.loader` and `fickling.exception`.

## Details

- Adds `requirements/extras/fickling.txt` with `fickling>=0.1.12,<0.2`.
- Adds `faust/serializers/_fickling.py` as the isolated Fickling adapter.
- Registers `pickle_fickling` as a base64-wrapped codec.
- Lets users configure `max_acceptable_severity` by passing Fickling's `fickling.loader.Severity` constants when constructing the codec, for example `pickle_fickling(max_acceptable_severity=Severity.SUSPICIOUS)`.
- Documents the `fickling` optional extra in the installation bundle list used by the GitHub Pages docs.
- Documents `pickle_fickling`, severity constants, default tolerance, and the isolated-adapter design in the user guide codecs section.
- Lazy-imports Fickling so normal installs are unchanged.
- Converts `fickling.exception.UnsafeFileError` into `pickle.UnpicklingError` so callers see the same error family as other pickle safety failures.
- Leaves `pickle_restricted` unchanged.

## Validation

- `python -m pytest tests/unit/serializers/test_codecs.py -q --no-cov`
- `black --check --diff --fast faust/serializers/codecs.py`
- `black --check --diff --fast faust/serializers/_fickling.py`
- `black --check --diff --fast tests/unit/serializers/test_codecs.py`
- `black --check --diff --fast setup.py`
- `isort --check --diff --project=faust faust/serializers/codecs.py faust/serializers/_fickling.py tests/unit/serializers/test_codecs.py setup.py`
- `flake8 faust/serializers/codecs.py faust/serializers/_fickling.py tests/unit/serializers/test_codecs.py setup.py`
- `bandit -b extra/bandit/baseline.json -c extra/bandit/config.yaml -r faust`
- `mypy -p faust`
- `git diff --check`

Docs build note: local `python -m sphinx -b html docs /tmp/faust-docs-fickling` could not run because Sphinx is not installed in the shared virtualenv.