### PR TITLE
Fix confluent threaded producer compatibility

### DIFF
--- a/faust/transport/drivers/confluent.py
+++ b/faust/transport/drivers/confluent.py
@@ -39,7 +39,14 @@ from faust.transport.consumer import (
     ensure_TP,
     ensure_TPset,
 )
-from faust.types import TP, AppT, ConsumerMessage, HeadersArg, RecordMetadata
+from faust.types import (
+    TP,
+    AppT,
+    ConsumerMessage,
+    FutureMessage,
+    HeadersArg,
+    RecordMetadata,
+)
 from faust.types.transports import (
     ConsumerT,
     PartitionsAssignedCallback,
@@ -479,6 +486,8 @@ class ProducerThread(QueueServiceThread):
     transport: "Transport"
     _producer: Optional[_Producer] = None
     _flush_soon: Optional[asyncio.Future] = None
+    event_queue: Optional[asyncio.Queue] = None
+    _stopping: bool = False
 
     def __init__(self, producer: "Producer", **kwargs: Any) -> None:
         self.producer = producer
@@ -487,6 +496,8 @@ class ProducerThread(QueueServiceThread):
         super().__init__(**kwargs)
 
     async def on_start(self) -> None:
+        self.event_queue = asyncio.Queue()
+        self._stopping = False
         self._producer = confluent_kafka.Producer(
             {
                 "bootstrap.servers": server_list(
@@ -502,8 +513,31 @@ class ProducerThread(QueueServiceThread):
             self._producer.flush()
 
     async def on_thread_stop(self) -> None:
+        self._stopping = True
+        queue = self.event_queue
+        if queue is not None:
+            while not queue.empty():
+                await self._publish_buffered(queue.get_nowait())
         if self._producer is not None:
             self._producer.flush()
+
+    async def _publish_buffered(self, fut: FutureMessage) -> None:
+        await fut.message.channel.publish_message(fut, wait=False)
+
+    @Service.task
+    async def _push_events(self) -> None:
+        queue = cast(asyncio.Queue, self.event_queue)
+        while not self._stopping or not queue.empty():
+            try:
+                fut = await asyncio.wait_for(queue.get(), timeout=0.1)
+            except asyncio.TimeoutError:
+                continue
+            await self._publish_buffered(fut)
+
+    def _ensure_producer(self) -> _Producer:
+        if self._producer is None:
+            raise RuntimeError("Producer not started")
+        return self._producer
 
     def produce(
         self,
@@ -517,10 +551,9 @@ class ProducerThread(QueueServiceThread):
         # here would paper over that bug rather than fix it.
         on_delivery: Callable,
     ) -> None:
-        if self._producer is None:
-            raise RuntimeError("Producer not started")
+        producer = self._ensure_producer()
         if partition is not None:
-            self._producer.produce(
+            producer.produce(
                 topic,
                 key,
                 value,
@@ -528,7 +561,7 @@ class ProducerThread(QueueServiceThread):
                 on_delivery=on_delivery,
             )
         else:
-            self._producer.produce(
+            producer.produce(
                 topic,
                 key,
                 value,
@@ -572,6 +605,10 @@ class Producer(base.Producer):
     def __post_init__(self) -> None:
         self._producer_thread = ProducerThread(self, loop=self.loop, beacon=self.beacon)
         self._quick_produce = self._producer_thread.produce
+
+    def create_threaded_producer(self) -> ProducerThread:
+        """Use the driver's producer thread for Faust's threaded buffer."""
+        return self._producer_thread
 
     async def _on_irrecoverable_error(self, exc: BaseException) -> None:
         consumer = self.transport.app.consumer
@@ -683,17 +720,8 @@ class Producer(base.Producer):
 
     def key_partition(self, topic: str, key: bytes) -> TP:
         """Return topic and partition destination for key."""
-        # Get the partition count for the topic
-        # XXX broken: ``ProducerThread.producer`` is the Faust Producer
-        # (i.e. ``self``), not the underlying confluent_kafka.Producer --
-        # that one is ``ProducerThread._producer``.  Faust producers have no
-        # ``list_topics``, so this raises AttributeError and
-        # ``Producer.key_partition`` is dead on arrival for this driver.
-        # Behaviour left untouched in this annotation-only pass; the fix is
-        # to read ``self._producer_thread._producer``.
-        metadata = self._producer_thread.producer.list_topics(  # type: ignore[attr-defined]  # noqa: E501
-            topic
-        )
+        producer = self._producer_thread._ensure_producer()
+        metadata = producer.list_topics(topic)
         partition_count = len(metadata.topics[topic].partitions)
 
         # Calculate the partition number based on the key hash

--- a/tests/unit/transport/drivers/test_confluent.py
+++ b/tests/unit/transport/drivers/test_confluent.py
@@ -5,6 +5,7 @@ around :pypi:`confluent_kafka` -- with the underlying ``confluent_kafka``
 ``Consumer``/``Producer`` mocked out, so no broker is required.
 """
 
+import asyncio
 from unittest.mock import Mock, patch
 
 import pytest
@@ -441,16 +442,21 @@ class TestProducer:
         # create_topic short-circuits (XXX) -- must not raise.
         assert await producer.create_topic("topic", 3, 1) is None
 
+    def test_create_threaded_producer__uses_existing_thread(self, *, producer):
+        assert producer.create_threaded_producer() is producer._producer_thread
+
     def test_key_partition(self, *, producer):
         metadata = Mock(name="metadata")
         topic_meta = Mock()
         topic_meta.partitions = {0: 1, 1: 1}
         metadata.topics = {"topic": topic_meta}
-        producer._producer_thread.producer = Mock()
-        producer._producer_thread.producer.list_topics.return_value = metadata
+        low_level_producer = Mock(name="confluent_kafka.Producer")
+        producer._producer_thread._ensure_producer.return_value = low_level_producer
+        low_level_producer.list_topics.return_value = metadata
         tp = producer.key_partition("topic", b"key")
         assert tp.topic == "topic"
         assert 0 <= tp.partition < 2
+        low_level_producer.list_topics.assert_called_once_with("topic")
 
 
 class TestProducerThread:
@@ -467,6 +473,8 @@ class TestProducerThread:
         with patch.object(mod.confluent_kafka, "Producer") as P:
             await producer_thread.on_start()
         assert producer_thread._producer is P.return_value
+        assert producer_thread.event_queue is not None
+        assert producer_thread._stopping is False
 
     @pytest.mark.asyncio
     async def test_flush(self, *, producer_thread):
@@ -484,6 +492,31 @@ class TestProducerThread:
         producer_thread._producer = Mock(name="_producer")
         await producer_thread.on_thread_stop()
         producer_thread._producer.flush.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_on_thread_stop__drains_event_queue(self, *, producer_thread):
+        producer_thread._producer = Mock(name="_producer")
+        producer_thread.event_queue = asyncio.Queue()
+        fut = Mock(name="future_message")
+        fut.message.channel.publish_message = AsyncMock()
+        await producer_thread.event_queue.put(fut)
+
+        await producer_thread.on_thread_stop()
+
+        fut.message.channel.publish_message.assert_awaited_once_with(fut, wait=False)
+        producer_thread._producer.flush.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_push_events__publishes_buffered_message(self, *, producer_thread):
+        producer_thread.event_queue = asyncio.Queue()
+        producer_thread._stopping = True
+        fut = Mock(name="future_message")
+        fut.message.channel.publish_message = AsyncMock()
+        await producer_thread.event_queue.put(fut)
+
+        await producer_thread._push_events()
+
+        fut.message.channel.publish_message.assert_awaited_once_with(fut, wait=False)
 
     def test_produce__with_partition(self, *, producer_thread):
         producer_thread._producer = Mock(name="_producer")

--- a/tests/unit/transport/drivers/test_confluent.py
+++ b/tests/unit/transport/drivers/test_confluent.py
@@ -520,7 +520,7 @@ class TestProducerThread:
         fut.message.channel.publish_message = AsyncMock()
         await producer_thread.event_queue.put(fut)
 
-        await producer_thread._push_events()
+        await ProducerThread._push_events.fun(producer_thread)
 
         fut.message.channel.publish_message.assert_awaited_once_with(fut, wait=False)
 

--- a/tests/unit/transport/drivers/test_confluent.py
+++ b/tests/unit/transport/drivers/test_confluent.py
@@ -442,6 +442,12 @@ class TestProducer:
         # create_topic short-circuits (XXX) -- must not raise.
         assert await producer.create_topic("topic", 3, 1) is None
 
+    def test___init____producer_threaded(self, app):
+        app.conf.producer_threaded = True
+        producer = Producer(app.transport)
+        assert producer.threaded_producer is producer._producer_thread
+        assert producer.buffer.threaded_producer is producer._producer_thread
+
     def test_create_threaded_producer__uses_existing_thread(self, *, producer):
         assert producer.create_threaded_producer() is producer._producer_thread
 


### PR DESCRIPTION
## Summary

- make the confluent driver implement Faust's existing `producer_threaded=True` hook
- reuse its `ProducerThread` as the threaded producer and expose the required event queue
- route buffered `FutureMessage` instances through the channel's public `publish_message` abstraction
- drain the queue before flushing during shutdown
- use the underlying confluent producer for `key_partition` metadata lookup

## Tests

Added focused coverage for queue setup, buffered-message dispatch, shutdown draining, threaded-producer reuse, and partition metadata lookup.