### PR TITLE
Add Cloudflare Web Analytics to documentation site

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,15 @@
+{%- extends "!layout.html" %}
+
+{# Cloudflare Web Analytics.
+
+   The published site (https://faust-streaming.github.io/faust) is the Sphinx
+   HTML tree the Pages workflow builds, so there is no hand-written page to
+   paste Cloudflare's snippet into -- a template override is what puts it on
+   every generated page instead.  `footer` is the last block before `</body>`
+   in the basic theme alabaster derives from, which is where the snippet
+   belongs; `super()` keeps the theme's own footer and GitHub banner.
+#}
+{%- block footer %}
+  {{ super() }}
+  <!-- Cloudflare Web Analytics --><script type='module' src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "13ad1310fd9d46ab969470ec2b361b4e"}'></script><!-- End Cloudflare Web Analytics -->
+{%- endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -8,8 +8,15 @@
    every generated page instead.  `footer` is the last block before `</body>`
    in the basic theme alabaster derives from, which is where the snippet
    belongs; `super()` keeps the theme's own footer and GitHub banner.
+
+   This is Cloudflare's documented classic `defer` form rather than a
+   `type='module'` one.  A module script is deferred anyway, so nothing is
+   lost -- but `document.currentScript` is null while a module executes, and
+   that is how a beacon reads the `data-cf-beacon` token off its own tag.  The
+   classic form keeps the token readable however the beacon looks it up, and
+   still runs in browsers that skip module scripts.
 #}
 {%- block footer %}
   {{ super() }}
-  <!-- Cloudflare Web Analytics --><script type='module' src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "13ad1310fd9d46ab969470ec2b361b4e"}'></script><!-- End Cloudflare Web Analytics -->
+  <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "13ad1310fd9d46ab969470ec2b361b4e"}'></script><!-- End Cloudflare Web Analytics -->
 {%- endblock %}


### PR DESCRIPTION
## Description

This PR adds Cloudflare Web Analytics tracking to the published Faust documentation site by implementing a Sphinx template override.

Since the documentation is generated as a static HTML site via the Pages workflow, a custom Jinja2 template is used to inject the Cloudflare analytics snippet into every generated page. The template extends the base layout and inserts the analytics script in the footer block, preserving the theme's existing footer content.

The analytics token is specific to the Faust documentation site and will only affect the published documentation at https://faust-streaming.github.io/faust.

## Test Plan

No testing needed. The template will be automatically applied during the Sphinx documentation build process. The analytics snippet is a standard Cloudflare Web Analytics implementation and will be included in all generated HTML pages.

https://claude.ai/code/session_01JEBC19ggdKCkK5sUt7UUSG